### PR TITLE
1. 为Types.lean 添加tag避免页面报错 2.让zhdocstring支持対属性和构造子的翻译文档

### DIFF
--- a/Manual/BasicProps.lean
+++ b/Manual/BasicProps.lean
@@ -8,6 +8,8 @@ import VersoManual
 
 import Manual.Meta
 import Manual.Papers
+import Manual.ZhDocString.ZhDocString
+import Manual.ZhDocString.BasicProps
 
 
 open Manual
@@ -115,7 +117,7 @@ In other words, because {lean}`Or` is not a {tech}[subsingleton], its proofs can
 In a {ref "tactics"}[tactic] proof, disjunctions can be proved using either constructor ({name}`Or.inl` or {name}`Or.inr`) explicitly via {tactic}`apply`.
 Assumptions of disjunctions in the context can be simplified using {tactic}`cases`, pattern matching with {tactic show:="match"}`Lean.Parser.Tactic.match`, or {tactic}`rcases`.
 
-{docstring Or}
+{zhdocstring Or ZhDoc.Or}
 
 When either disjunct is {tech}[decidable], it becomes possible to use {lean}`Or` to compute data.
 This is because the decision procedure's result provides a suitable branch condition.

--- a/Manual/Types.lean
+++ b/Manual/Types.lean
@@ -13,7 +13,7 @@ import Manual.Language.InductiveTypes
 import Manual.Quotients
 
 import Manual.ZhDocString.ZhDocString
-import Manual.ZhDocString.Chapter4
+import Manual.ZhDocString.Types
 
 open Verso.Genre Manual
 open Verso.Genre.Manual.InlineLean
@@ -283,6 +283,7 @@ tag := "propositions"
 
 # 命题 (Propositions)
 %%%
+file := "Propositions"
 tag := "propositions"
 %%%
 
@@ -362,6 +363,10 @@ This means that the following examples are accepted:
 -/
 
 # 宇宙（Universe）
+%%%
+file := "Universe"
+tag := "universe"
+%%%
 
 类型由 {deftech key := "universes"}_宇宙_ 分类。{index}[universe]{margin}[宇宙有时也称为 {deftech key := "sorts"}_类别(sort)_。]
 每个宇宙都有一个 自然数{deftech key := "universe level"}_层级(level)_。{index subterm := "of universe"}[level]

--- a/Manual/ZhDocString/BasicProps.lean
+++ b/Manual/ZhDocString/BasicProps.lean
@@ -1,0 +1,29 @@
+namespace ZhDoc
+
+/-
+/--
+`Or a b`, or `a ∨ b`, is the disjunction of propositions. There are two
+constructors for `Or`, called `Or.inl : a → a ∨ b` and `Or.inr : b → a ∨ b`,
+and you can use `match` or `cases` to destruct an `Or` assumption into the
+two cases.
+-/
+inductive Or (a b : Prop) : Prop where
+  /-- `Or.inl` is "left injection" into an `Or`. If `h : a` then `Or.inl h : a ∨ b`. -/
+  | inl (h : a) : Or a b
+  /-- `Or.inr` is "right injection" into an `Or`. If `h : b` then `Or.inr h : a ∨ b`. -/
+  | inr (h : b) : Or a b
+-/
+
+
+/--
+`Or a b`，或 `a ∨ b`，是命题的析取。
+`Or` 有两个构造器，分别是 `Or.inl : a → a ∨ b` 和 `Or.inr : b → a ∨ b`，
+可以使用 `match` 或 `cases` 将 `Or` 的假设析构为两种情况。
+-/
+inductive Or (a b : Prop) : Prop where
+  /-- `Or.inl` 是向 `Or` 的“左注入”。如果 `h : a`，那么 `Or.inl h : a ∨ b`。-/
+  | inl (h : a) : Or a b
+  /-- `Or.inr` 是向 `Or` 的“右注入”。如果 `h : b`，那么 `Or.inr h : a ∨ b`。-/
+  | inr (h : b) : Or a b
+
+end ZhDoc

--- a/Manual/ZhDocString/Types.lean
+++ b/Manual/ZhDocString/Types.lean
@@ -79,6 +79,11 @@ Examples:
  * `([.up (by trivial), .up (by simp), .up (by decide)] : List (PLift True))`
  * `(Nat : Type 0)`
  * `(PLift Nat : Type 1)`
+structure PLift (α : Sort u) : Type u where
+  /- Wraps a proof or value to increase its type's universe level by 1. -/
+  up ::
+  /- Extracts a wrapped proof or value from a universe-lifted proposition or type. -/
+  down : α
 -/
 
 /--
@@ -96,10 +101,8 @@ Examples:
  * `(PLift Nat : Type 1)`
 -/
 structure PLift (α : Sort u) : Type u where
-  /- Wraps a proof or value to increase its type's universe level by 1. -/
   /-- 将一个证明或值包装起来,以使其类型的宇宙层级增加1。 -/
   up ::
-  /- Extracts a wrapped proof or value from a universe-lifted proposition or type. -/
   /-- 从提升到宇宙的命题或类型中提取一个封装的证明或值。 -/
   down : α
 
@@ -122,7 +125,19 @@ Examples:
  * `(ULift Nat : Type 1)`
  * `(ULift Nat : Type 5)`
  * `(ULift.{7} (PUnit : Type 3) : Type 7)`
+-- The universe variable `r` is written first so that `ULift.{r} α` can be used
+-- when `s` can be inferred from the type of `α`.
+structure ULift.{r, s} (α : Type s) : Type (max s r) where
+  /- Wraps a value to increase its type's universe level. -/
+  /-- 包装一个值,以提升其类型的宇宙等级。 -/
+  up ::
+  /- Extracts a wrapped value from a universe-lifted type. -/
+  /- 从一个被提升宇宙的类型中提取出被包装的值。 -/
+  down : α
+
+end ZhDoc
 -/
+
 /--
 提升一个类型到更高的宇宙层级。
 
@@ -132,14 +147,11 @@ Examples:
 
 相关的类型 `PLift` 可以用来将命题或类型的宇宙提升一级。
 -/
--- The universe variable `r` is written first so that `ULift.{r} α` can be used
--- when `s` can be inferred from the type of `α`.
+-- 首先写出通用变量 `r`，这样当 `α` 的类型能够推断出 `s` 时，可以使用 `ULift.{r} α`
 structure ULift.{r, s} (α : Type s) : Type (max s r) where
-  /- Wraps a value to increase its type's universe level. -/
   /-- 包装一个值,以提升其类型的宇宙等级。 -/
   up ::
-  /- Extracts a wrapped value from a universe-lifted type. -/
-  /- 从一个被提升宇宙的类型中提取出被包装的值。 -/
+  /-- 从一个被提升宇宙的类型中提取出被包装的值。 -/
   down : α
 
 end ZhDoc

--- a/README.md
+++ b/README.md
@@ -13,12 +13,20 @@
 
 ## {docstring xxx}的翻译
 由于{docstring xxx}会直接引用lean的源码，因此本仓库在Manual目录下创建了ZhDocString目录，其中`Manual/ZhDocString/ZhDocString.lean`定义了`zhdocstring` 
-用法如下 `{zhdocstring 原对象 翻译过的对象}`
-其中翻译过的对象可以在 `Manual/ZhDocString/`下创建一个对应章节的lean文件，然后通过namespace创建一个和原对象同名的对象
-如`Chapter4.lean`中创建了`ZhDoc.propext` 并提供了与`propext`对应的翻译文档
+用法如下 
+```{zhdocstring 原对象 翻译过的对象}```
+
+其中翻译过的对象可以在 `Manual/ZhDocString/`下创建一个对应文件的lean文件，然后通过namespace创建一个和原对象同名的对象
+
+如`Manual/ZhDocString/Types.lean`中创建了`ZhDoc.propext` 并提供了与`propext`对应的翻译文档
+
 然后在原文中使用`{docstring propext}`的地方 替换为 `{zhdocstring propext ZhDoc.propext}`
+
 `zhdocstring`会使用`propext`的签名和连接，但是会使用`ZhDoc.propext`文档块
+
 以此来完成対{docstring xxx}的翻译
+
+注意，源码中的文档块以`/--`开头`-/`结尾，必须対每个属性/构造子编写文档，否则会编译报错
 
 
 ## 特别注意


### PR DESCRIPTION
# 提交 PR 前请阅读

* 这个repo是 [leanprover/reference-manual](https://github.com/leanprover/reference-manual) 的中文翻译文档，如果是想为lean社区贡献新内容/修改错误, 请为原文档提交PR

* 提交PR前务必本地执行 `deploy/generate.sh` 确保无编译错误, 无任何`error`输出, **`lake exe generate-manual --depth 2`不能保证无错误**
---