### PR TITLE
doc: distinguish disequality from order inequalities

### DIFF
--- a/Manual/Grind/Algebra.lean
+++ b/Manual/Grind/Algebra.lean
@@ -183,7 +183,7 @@ variable {a b p : α} [Field α]
 ```
 `ring` 求解器也支持 {name}`Field`。
 如果有可用的 {name}`Field` 实例，求解器会将项 `a / b` 预处理为 `a * b⁻¹`。
-它还会将每个不等式 `p ≠ 0` 重写为等式 `p * p⁻¹ = 1`。
+它还会将每个不等关系 `p ≠ 0` 重写为等式 `p * p⁻¹ = 1`。
 :::
 
 ::::example "域与 `grind`"
@@ -282,7 +282,7 @@ example [Field α] (a : α) : (2 * a)⁻¹ = a⁻¹ / 2 := by grind
 ```
 
 在以下示例中，`ring` 无需进行任何情形拆分，因为
-目标包含不等式 `y ≠ 0` 和 `w ≠ 0`。
+目标包含不等关系 `y ≠ 0` 和 `w ≠ 0`。
 
 ```lean
 example [Field α] {x y z w : α} :

--- a/Manual/ZhDocString/Grind.lean
+++ b/Manual/ZhDocString/Grind.lean
@@ -251,7 +251,7 @@ def grindLR := Prop
 def grindRL := Prop
 
 /--
-`←=` 修饰符专用于对等式进行后向推理，与其他 `grind` 修饰符不同。当定理结论是等式命题且以 `@[grind ←=]` 标注时，只要假设了对应的不等式，`grind` 就会实例化该定理；这是因为 `grind` 的所有证明均采用反证法。通常，`grind` 属性生成模式时不会考虑 `=` 符号。
+`←=` 修饰符专用于对等式进行后向推理，与其他 `grind` 修饰符不同。当定理结论是等式命题且以 `@[grind ←=]` 标注时，只要假设了对应的不等关系，`grind` 就会实例化该定理；这是因为 `grind` 的所有证明均采用反证法。通常，`grind` 属性生成模式时不会考虑 `=` 符号。
 -/
 def grindEqBwd := Prop
 
@@ -260,7 +260,7 @@ def grindEqBwd := Prop
 -/
 def grindFunCC := Prop
 
-/-- `ext` 修饰符标记供 `grind` 使用的外延性定理。例如，标准库用此属性标记 `funext`。每当 `grind` 遇到不等式 `a ≠ b` 时，它会尝试应用类型与 `a`、`b` 相匹配的外延性定理。 -/
+/-- `ext` 修饰符标记供 `grind` 使用的外延性定理。例如，标准库用此属性标记 `funext`。每当 `grind` 遇到不等关系 `a ≠ b` 时，它会尝试应用类型与 `a`、`b` 相匹配的外延性定理。 -/
 def grindExt := Prop
 
 /-- `inj` 修饰符标记供 `grind` 使用的单射性定理。定理结论必须形如 `Function.Injective f`，且项 `f` 至少包含一个常量符号。 -/


### PR DESCRIPTION
## 概要

修复 Grind 译文中将 `≠` 称为“不等式”的四处术语问题，统一改为“不等关系”；真正的 `<`、`≤` 顺序不等式仍保留“不等式”。

## 验证

- `lake -Kjobs=2 build Manual.Grind`：280 jobs 成功
- `git diff --check`
- `不等式` 与 `≠` 同行残留：0

请使用普通 merge commit。