### PR TITLE
doc: link grind reference to Chinese tutorial

### DIFF
--- a/Manual/Grind.lean
+++ b/Manual/Grind.lean
@@ -54,7 +54,7 @@ tag := "grind-tactic"
 %%%
 
 :::tutorials
- * {ref "grind-index-map" (remote := "tutorials")}[使用 `grind` 处理有序映射]
+ * [使用 `grind` 处理有序映射](https://www.leanprover.cn/projects/grind-index-map/)
 :::
 
 ```lean -show


### PR DESCRIPTION
## 概要

将 `grind` 参考章节中的“使用 `grind` 处理有序映射”链接改为 Lean 中文社区已翻译的教程：

https://www.leanprover.cn/projects/grind-index-map/

## 验证

- 目标页面 HTTP 200
- `lake -Kjobs=2 build Manual.Grind`：280 jobs 成功
- Preview HTML 成功，链接正确渲染
- 0 duplicate tag / unresolved reference / error
- `git diff --check`

请使用普通 merge commit。