### PR TITLE
doc: translate chapter 24 build tools

### DIFF
--- a/Manual/BuildTools.lean
+++ b/Manual/BuildTools.lean
@@ -21,49 +21,49 @@ open Verso.Genre.Manual.InlineLean
 open Lean.Elab.Tactic.GuardMsgs.WhitespaceMode
 
 
-#doc (Manual) "Build Tools and Distribution" =>
+#doc (Manual) "构建工具与发行" =>
 %%%
 tag := "build-tools-and-distribution"
-shortContextTitle := "Build Tools"
+shortContextTitle := "构建工具"
 %%%
 
 :::paragraph
-The Lean {deftech}_toolchain_ is the collection of command-line tools that are used to check proofs and compile programs in collections of Lean files.
-Toolchains are managed by `elan`, which installs toolchains as needed.
-Lean toolchains are designed to be self-contained, and most command-line users will never need to explicitly invoke any other than `lake` and `elan`.
-They contain the following tools:
+Lean {deftech (key := "toolchain")}[工具链]是一组命令行工具，用于检查证明并编译由多个 Lean 文件组成的程序。
+工具链由 `elan` 管理；它会按需安装工具链。
+Lean 工具链采用自包含设计，大多数命令行用户除了 `lake` 和 `elan` 之外，无需显式调用其中的其他工具。
+其中包含以下工具：
 
 : `lean`
 
-  The Lean compiler, used to elaborate and compile a Lean source file.
+  Lean 编译器，用于精译和编译 Lean 源文件。
 
 : `lake`
 
-  The Lean build tool, used to incrementally invoke `lean` and other tools while tracking dependencies.
+  Lean 构建工具，在跟踪依赖关系的同时增量调用 `lean` 和其他工具。
 
 : `leanc`
 
-  The C compiler that ships with Lean, which is a version of [Clang](https://clang.llvm.org/).
+  Lean 随附的 C 编译器，它是 [Clang](https://clang.llvm.org/) 的一个版本。
 
 : `leanmake`
 
-  An implementation of the `make` build tool, used for compiling C dependencies.
+  `make` 构建工具的一种实现，用于编译 C 依赖项。
 
 : `leanchecker`
 
-  A tool that replays elaboration results from {tech}[`.olean` files] through the Lean kernel, providing additional assurance that all terms were properly checked.
+  一种通过 Lean 内核重放 {tech (key := ".olean files")}[`.olean` 文件]中精译结果的工具，为所有项均已得到正确检查提供额外保证。
 :::
 
-In addition to these build tools, toolchains contain files that are needed to build Lean code.
-This includes source code, {tech}[`.olean` files], compiled libraries, C header files, and the compiled Lean run-time system.
-They also include external proof automation tools that are used by tactics included with Lean, such as `cadical` for {tactic}`bv_decide`.
+除这些构建工具外，工具链还包含构建 Lean 代码所需的文件。
+其中包括源代码、{tech (key := ".olean files")}[`.olean` 文件]、已编译的库、C 头文件以及已编译的 Lean 运行时系统。
+其中还包括 Lean 随附策略所使用的外部证明自动化工具，例如 {tactic}`bv_decide` 使用的 `cadical`。
 
 
 {include 0 Manual.BuildTools.Lake}
 
 {include 0 Manual.BuildTools.Elan}
 
-# Reservoir
+# Reservoir 包仓库
 %%%
 tag := "reservoir"
 draft := true
@@ -71,7 +71,7 @@ draft := true
 
 
 ::: planned 76
- * Concepts
- * Package and toolchain versions
- * Tags and builds
+ * 概念
+ * 包与工具链版本
+ * 标签与构建
 :::

--- a/Manual/BuildTools.lean
+++ b/Manual/BuildTools.lean
@@ -25,6 +25,7 @@ open Lean.Elab.Tactic.GuardMsgs.WhitespaceMode
 %%%
 tag := "build-tools-and-distribution"
 shortContextTitle := "构建工具"
+file := "Build-Tools-and-Distribution"
 %%%
 
 :::paragraph

--- a/Manual/BuildTools/Elan.lean
+++ b/Manual/BuildTools/Elan.lean
@@ -19,120 +19,120 @@ open Verso.Genre.Manual.InlineLean
 
 open Lean.Elab.Tactic.GuardMsgs.WhitespaceMode
 
-#doc (Manual) "Managing Toolchains with Elan" =>
+#doc (Manual) "使用 Elan 管理工具链" =>
 %%%
 tag := "elan"
 shortContextTitle := "Elan"
 %%%
 
-Elan is the Lean toolchain manager.
-It is responsible both for installing {tech}[toolchains] and for running their constituent programs.
-Elan makes it possible to seamlessly work on a variety of projects, each of which is designed to be built with a particular version of Lean, without having to manually install and select toolchain versions.
-Each project is typically configured to use a particular version, which is transparently installed as needed, and changes to the Lean version are tracked automatically.
+Elan 是 Lean 工具链管理器。
+它既负责安装{tech (key := "toolchains")}[工具链]，也负责运行工具链中的程序。
+借助 Elan，可以无缝处理各种项目；每个项目都针对特定 Lean 版本进行构建，而无需手动安装和选择工具链版本。
+每个项目通常配置为使用某个特定版本；该版本会按需透明地安装，而 Lean 版本的变更会自动受到跟踪。
 
-# Selecting Toolchains
+# 选择工具链
 %%%
 tag := "elan-toolchain-versions"
 %%%
 
-When using Elan, the version of each tool on the {envVar}`PATH` is a proxy that invokes the correct version.
-The proxy determines the appropriate toolchain version for the current context, ensures that it is installed, and then invokes the underlying tool in the appropriate toolchain installation.
-These proxies can be instructed to use a specific version by passing it as an argument prefixed with `+`, so `lake +4.0.0` invokes `lake` version `4.0.0`, after installing it if necessary.
+使用 Elan 时，{envVar}`PATH` 中每个工具的版本都是一个调用正确版本的代理。
+代理会为当前上下文确定适当的工具链版本，确保该版本已安装，然后调用相应工具链安装中的底层工具。
+可以传入以 `+` 为前缀的参数，指示这些代理使用特定版本；因此 `lake +4.0.0` 会调用 `4.0.0` 版的 `lake`，必要时先安装它。
 
 
-## Toolchain Identifiers
+## 工具链标识符
 %%%
 tag := "elan-channels"
 %%%
 
-Toolchains are specified by providing a toolchain identifier that is either a {deftech}_channel_, which identifies a particular type of Lean release, and optionally an origin, or a {deftech}_custom toolchain name_ established by {elan}`toolchain link`.
-Channels may be:
+工具链通过工具链标识符指定；标识符可以是标识某类 Lean 发行版并可选带有来源的{deftech (key := "channel")}[通道]，也可以是由 {elan}`toolchain link` 建立的{deftech (key := "custom toolchain name")}[自定义工具链名称]。
+通道可以是：
 
  : `stable`
 
-  The latest stable Lean release. Elan automatically tracks stable releases and offers to upgrade when a new one is released.
+  最新的 Lean 稳定发行版。Elan 会自动跟踪稳定发行版，并在新版本发布时提示升级。
 
  : `beta`
 
-  The latest release candidate. Release candidates are builds of Lean that are intended to become the next stable release. They are made available for widespread user testing.
+  最新的候选发行版。候选发行版是计划成为下一个稳定发行版的 Lean 构建，供广大用户测试。
 
  : `nightly`
 
-   The latest nightly build. Nightly builds are useful for experimenting with new Lean features to provide feedback to the developers.
+   最新的每夜构建。每夜构建适合试用 Lean 的新功能并向开发者提供反馈。
 
- : A version number or specific nightly release
+ : 版本号或特定的每夜发行版
 
-    Each Lean version number identifies a channel that contains only that release.
-    The version number may optionally be preceded with a `v`, so `v4.17.0` and `4.17.0` are equivalent.
-    Similarly, `nightly-YYYY-MM-DD` specifies the nightly release from the specified date.
-    A project's {tech}[toolchain file] should typically contain a specific version of Lean, rather than a general channel, to make it easier to coordinate between developers and to build and test older versions of the project.
-    An archive of Lean releases and nightly builds is maintained.
+    每个 Lean 版本号都标识一个仅包含该发行版的通道。
+    版本号前可以带有 `v`，因此 `v4.17.0` 与 `4.17.0` 等价。
+    类似地，`nightly-YYYY-MM-DD` 指定相应日期的每夜发行版。
+    项目的{tech (key := "toolchain file")}[工具链文件]通常应包含具体的 Lean 版本，而不是宽泛的通道，以便开发者相互协调，并构建和测试项目的旧版本。
+    Lean 发行版和每夜构建有一份持续维护的归档。
 
- : A custom local toolchain
+ : 自定义本地工具链
 
-    The command {elan}`toolchain link` can be used to establish a custom toolchain name in Elan for a local build of Lean.
-    This is especially useful when working on the Lean compiler itself.
+    可以使用 {elan}`toolchain link` 命令，在 Elan 中为 Lean 的本地构建建立自定义工具链名称。
+    这在开发 Lean 编译器本身时尤其有用。
 
-Specifying an {deftech}_origin_ instructs Elan to install Lean toolchains from a particular source.
-By default, this is the official project repository on GitHub, identified as [`leanprover/lean4`](https://github.com/leanprover/lean4/releases).
-If specified, an origin should precede the channel, with a colon, so `stable` is equivalent to `leanprover/lean4:stable`.
-When installing nightly releases, `-nightly` is appended to the origin, so `leanprover/lean4:nightly-2025-03-25` consults the [`leanprover/lean4-nightly`](https://github.com/leanprover/lean4-nightly/releases) repository to download releases.
-Origins are not used for custom toolchain names.
+指定{deftech (key := "origin")}[来源]会指示 Elan 从特定源安装 Lean 工具链。
+默认情况下，这是 GitHub 上标识为 [`leanprover/lean4`](https://github.com/leanprover/lean4/releases) 的官方项目仓库。
+如果指定来源，它应位于通道之前，并用冒号分隔，因此 `stable` 等价于 `leanprover/lean4:stable`。
+安装每夜发行版时，会向来源追加 `-nightly`，因此 `leanprover/lean4:nightly-2025-03-25` 会查询 [`leanprover/lean4-nightly`](https://github.com/leanprover/lean4-nightly/releases) 仓库以下载发行版。
+自定义工具链名称不使用来源。
 
-## Determining the Current Toolchain
+## 确定当前工具链
 %%%
 tag := "elan-toolchain-config"
 %%%
 
-Elan associates toolchains with directories, and uses the toolchain of the most recent parent directory of the current working directory that has a configured toolchain.
-A directory's toolchain may result from a toolchain file or from an override configured with {ref "elan-override"}[`elan override`].
+Elan 将工具链与目录关联，并使用当前工作目录向上最近的、已配置工具链的父目录所对应的工具链。
+目录的工具链可能来自工具链文件，也可能来自使用 {ref "elan-override"}[`elan override`] 配置的覆盖项。
 
-The current toolchain is determined by first searching for a configured toolchain for the current directory, walking up through parent directories until a toolchain version is found or there are no more parents.
-A directory has a configured toolchain if there is a configured {tech}[toolchain override] for the directory or if it contains a `lean-toolchain` file.
-More recent parents take precedence over their ancestors, and if a directory has both an override and a toolchain file, then the override takes precedence.
-If no directory toolchain is found, then Elan's configured {deftech}_default toolchain_ is used as a fallback.
+确定当前工具链时，首先查找为当前目录配置的工具链，然后逐级向上检查父目录，直到找到工具链版本或不再有父目录。
+若某目录配置了{tech (key := "toolchain override")}[工具链覆盖项]，或包含 `lean-toolchain` 文件，则该目录已配置工具链。
+较近的父目录优先于其祖先目录；如果一个目录同时有覆盖项和工具链文件，则覆盖项优先。
+如果没有找到目录工具链，则以 Elan 配置的{deftech (key := "default toolchain")}[默认工具链]作为后备。
 
-The most common way to configure a Lean toolchain is with a {deftech}_toolchain file_.
-The toolchain file is a text file named `lean-toolchain` that contains a single line with a valid {ref "elan-channels"}[toolchain identifier].
-This file is typically located in the root directory of a project and checked in to version control with the code, ensuring that everyone working on the project uses the same version.
-Updating to a new Lean toolchain requires only editing this file, and the new version is automatically downloaded and run the next time a Lean file is opened or built.
+配置 Lean 工具链最常见的方式是使用{deftech (key := "toolchain file")}[工具链文件]。
+工具链文件是名为 `lean-toolchain` 的文本文件，其中只有一行有效的{ref "elan-channels"}[工具链标识符]。
+该文件通常位于项目根目录，并与代码一同纳入版本控制，确保项目的所有开发者使用相同版本。
+更新到新的 Lean 工具链只需编辑此文件；下次打开或构建 Lean 文件时，新版本便会自动下载并运行。
 
-In certain advanced use cases where more flexibility is required, a {deftech}_toolchain override_ can be configured.
-Like toolchain files, overrides associate a toolchain version with a directory and its children.
-Unlike toolchain files, overrides are stored in Elan's configuration rather than in a local file.
-They are typically used when a specific local configuration is required that does not make sense for other developers, such as testing a project with a locally-built Lean compiler.
+在某些需要更大灵活性的高级用例中，可以配置{deftech (key := "toolchain override")}[工具链覆盖项]。
+与工具链文件一样，覆盖项将工具链版本与某个目录及其子目录关联。
+与工具链文件不同，覆盖项存储在 Elan 的配置中，而不是本地文件中。
+它们通常用于需要不适合其他开发者的特定本地配置时，例如使用本地构建的 Lean 编译器测试项目。
 
-# Toolchain Locations
+# 工具链位置
 %%%
 tag := "elan-dir"
 %%%
 
-By default, Elan stores installed toolchains in `.elan/toolchains` in the user's home directory, and its proxies are kept in `.elan/bin`, which is added to the path when Elan is installed.
-The environment variable {envVar +def}`ELAN_HOME` can be used to change this location.
-It should be set both prior to installing Elan and in all sessions that use Lean in order to ensure that Elan's files are found.
+默认情况下，Elan 将已安装的工具链存储在用户主目录的 `.elan/toolchains` 中，其代理则保存在 `.elan/bin` 中；安装 Elan 时会将后者添加到路径。
+可以使用环境变量 {envVar +def}`ELAN_HOME` 更改此位置。
+为确保能找到 Elan 的文件，应在安装 Elan 之前以及所有使用 Lean 的会话中设置它。
 
-# Command-Line Interface
+# 命令行界面
 %%%
 tag := "elan-cli"
 %%%
 
-In addition to the proxies that automatically select, install, and invoke the correct versions of Lean tools, Elan provides a command-line interface for querying and configuring its settings.
-This tool is called `elan`.
-Like {ref "lake"}[Lake], its command-line interface is structured around subcommands.
+除了自动选择、安装并调用正确版本 Lean 工具的代理外，Elan 还提供用于查询和配置其设置的命令行界面。
+该工具名为 `elan`。
+与 {ref "lake"}[Lake] 类似，其命令行界面围绕子命令组织。
 
-Elan can be invoked with following flags:
+调用 Elan 时可以使用以下标志：
 
  : {elanOptDef flag}`--help` or {elanOptDef flag}`-h`
 
-  Describes the current subcommand in detail.
+  详细说明当前子命令。
 
  : {elanOptDef flag}`--verbose` or {elanOptDef flag}`-v`
 
-  Enables verbose output.
+  启用详细输出。
 
  : {elanOptDef flag}`--version` or {elanOptDef flag}`-V`
 
-  Displays the Elan version.
+  显示 Elan 版本。
 
 
 
@@ -167,12 +167,12 @@ DISCUSSION:
     executable.
 ```
 
-## Querying Toolchains
+## 查询工具链
 %%%
 tag := "elan-show"
 %%%
 
-The {elan}`show` command displays the current toolchain (as determined by the current directory) and lists all installed toolchains.
+{elan}`show` 命令显示当前工具链（由当前目录确定），并列出所有已安装的工具链。
 
 
 ```elanHelp "show"
@@ -193,12 +193,12 @@ DISCUSSION:
 ```
 
 :::elan show
-Shows the name of the active toolchain and the version of `lean`.
+显示活动工具链的名称和 `lean` 的版本。
 
-If there are multiple toolchains installed, then they are all listed.
+如果安装了多个工具链，则会全部列出。
 :::
 
-Here is typical output from {elan}`show` in a project with a `lean-toolchain` file:
+下面是在含有 `lean-toolchain` 文件的项目中运行 {elan}`show` 的典型输出：
 ```
 installed toolchains
 --------------------
@@ -214,18 +214,18 @@ active toolchain
 leanprover/lean4:v4.9.0 (overridden by '/PATH/TO/PROJECT/lean-toolchain')
 Lean (version 4.9.0, arm64-apple-darwin23.5.0, commit 8f9843a4a5fe, Release)
 ```
-The `installed toolchains` section lists all the toolchains currently available on the system.
-The `active toolchain` section identifies the current toolchain and describes how it was selected.
-In this case, the toolchain was selected due to a `lean-toolchain` file.
+`installed toolchains` 一节列出系统上当前可用的所有工具链。
+`active toolchain` 一节标识当前工具链，并说明其选择方式。
+在此例中，工具链是根据 `lean-toolchain` 文件选择的。
 
 
-## Setting the Default Toolchain
+## 设置默认工具链
 %%%
 tag := "elan-default"
 %%%
 
-Elan's configuration file specifies a {tech}[default toolchain] to be used when there is no `lean-toolchain` file or {tech}[toolchain override] for the current directory.
-Rather than manually editing the file, this value is typically changed using the {elan}`default` command.
+Elan 的配置文件指定一个{tech (key := "default toolchain")}[默认工具链]，在当前目录没有 `lean-toolchain` 文件或{tech (key := "toolchain override")}[工具链覆盖项]时使用。
+通常使用 {elan}`default` 命令更改此值，而不是手动编辑该文件。
 
 ```elanHelp "default"
 elan-default
@@ -246,20 +246,20 @@ DISCUSSION:
 ```
 
 :::elan default "toolchain"
-Sets the default toolchain to {elanMeta}`toolchain`, which should be a {ref "elan-channels"}[valid toolchain identifier] such as `stable`, `nightly`, or `4.17.0`.
+将默认工具链设置为 {elanMeta}`toolchain`；它应是{ref "elan-channels"}[有效的工具链标识符]，例如 `stable`、`nightly` 或 `4.17.0`。
 :::
 
-## Managing Installed Toolchains
+## 管理已安装的工具链
 %%%
 tag := "elan-toolchain"
 %%%
 
-The `elan toolchain` family of subcommands is used to manage the installed toolchains.
-Toolchains are stored in Elan's {ref "elan-dir"}[toolchain directory].
+`elan toolchain` 子命令族用于管理已安装的工具链。
+工具链存储在 Elan 的{ref "elan-dir"}[工具链目录]中。
 
-Installed toolchains can take up substantial disk space.
-Elan tracks the Lean projects in which it is invoked, saving a list.
-This list of projects can be used to determine which toolchains are in active use and automatically delete unused toolchain versions with {elan}`toolchain gc`.
+已安装的工具链可能占用大量磁盘空间。
+Elan 会跟踪曾在其中调用过它的 Lean 项目，并保存一份列表。
+这份项目列表可用于确定哪些工具链正在使用，并通过 {elan}`toolchain gc` 自动删除未使用的工具链版本。
 
 ```elanHelp "toolchain"
 elan-toolchain
@@ -318,7 +318,7 @@ FLAGS:
 ```
 
 :::elan toolchain list
-Lists the currently-installed toolchains. This is a subset of the output of {elan}`show`.
+列出当前已安装的工具链。这是 {elan}`show` 输出的一个子集。
 :::
 
 ```elanHelp "toolchain" "install"
@@ -337,8 +337,8 @@ ARGS:
 ```
 
 :::elan toolchain install "toolchain"
-Installs the indicated {elanMeta}`toolchain`.
-The toolchain's name should be {ref "elan-channels"}[an identifier that's suitable for inclusion in a `lean-toolchain` file].
+安装指定的 {elanMeta}`toolchain`。
+工具链名称应是{ref "elan-channels"}[适合写入 `lean-toolchain` 文件的标识符]。
 :::
 
 
@@ -358,9 +358,9 @@ ARGS:
 ```
 
 :::elan toolchain uninstall "toolchain"
-Uninstalls the indicated {elanMeta}`toolchain`.
-The toolchain's name should the name of an installed toolchain.
-Use {elan}`toolchain list` to see the installed toolchains with their names.
+卸载指定的 {elanMeta}`toolchain`。
+工具链名称应为某个已安装工具链的名称。
+使用 {elan}`toolchain list` 查看已安装工具链及其名称。
 :::
 
 ```elanHelp "toolchain" "link"
@@ -397,7 +397,7 @@ DISCUSSION:
 
 :::elan toolchain link "«local-name» path"
 
-Creates a new local toolchain named {elanMeta}`local-name`, using the Lean toolchain found at {elanMeta}`path`.
+使用在 {elanMeta}`path` 处找到的 Lean 工具链，创建名为 {elanMeta}`local-name` 的新本地工具链。
 
 :::
 
@@ -428,28 +428,28 @@ DISCUSSION:
 
 :::elan toolchain gc "[\"--delete\"] [\"--json\"]"
 
-This command is still considered experimental.
+此命令目前仍被视为实验性命令。
 
-Determines which of the installed toolchains are in use, offering to delete those that are not.
-All the installed toolchains are listed, separated into those that are in use and those that are not.
+确定已安装工具链中哪些正在使用，并提议删除未使用的工具链。
+所有已安装的工具链都会列出，并分成正在使用和未使用两类。
 
-A toolchain is classified as “in use” if
- * it is the default toolchain,
- * it is registered as an override, or
- * there is a directory with a `lean-toolchain` file referencing the toolchain and elan has been used in the directory before.
+如果满足以下条件，工具链会被归类为“正在使用”：
+ * 它是默认工具链；
+ * 它被注册为覆盖项；或者
+ * 某目录的 `lean-toolchain` 文件引用了该工具链，并且此前曾在该目录中使用过 elan。
 
-For safety reasons, {elan}`toolchain gc` will not actually delete any toolchains unless the {elanOptDef flag}`--delete` flag is passed.
-This may be relaxed in the future when the implementation is deemed sufficiently mature.
-The {elanOptDef flag}`--json` flag causes {elan}`toolchain gc` to emit the list of used and unused toolchains in a JSON format that's suitable for other tools.
+出于安全考虑，除非传入 {elanOptDef flag}`--delete` 标志，否则 {elan}`toolchain gc` 不会实际删除任何工具链。
+将来当实现被认为足够成熟时，可能会放宽这一要求。
+{elanOptDef flag}`--json` 标志使 {elan}`toolchain gc` 以适合其他工具处理的 JSON 格式输出已使用和未使用工具链的列表。
 :::
 
-## Managing Directory Overrides
+## 管理目录覆盖项
 %%%
 tag := "elan-override"
 %%%
 
-Directory-specific {tech}[toolchain overrides] are a local configuration that takes precedence over `lean-toolchain` files.
-The `elan override` commands manage overrides.
+目录专属的{tech (key := "toolchain overrides")}[工具链覆盖项]是一种优先于 `lean-toolchain` 文件的本地配置。
+`elan override` 命令用于管理覆盖项。
 
 ```elanHelp "override"
 elan-override
@@ -494,31 +494,31 @@ DISCUSSION:
 
 
 :::elan override list
-Lists all the currently configured directory overrides in two columns.
-The left column contains the directories in which the Lean version is overridden, and the right column lists the toolchain version.
+以两列列出当前配置的所有目录覆盖项。
+左列包含 Lean 版本被覆盖的目录，右列列出工具链版本。
 :::
 
 
 :::elan override set "toolchain"
-Sets {elanMeta}`toolchain` as an override for the current directory.
+将 {elanMeta}`toolchain` 设置为当前目录的覆盖项。
 :::
 
 
 
 
 :::elan override unset "[\"--nonexistent\"] [\"--path\" path]"
-If {elanOptDef flag}`--nonexistent` flag is provided, all overrides that are configured for directories that don't currently exist are removed.
-If {elanOptDef option}`--path` is provided, then the override set for {elanMeta}`path` is removed.
-Otherwise, the override for the current directory is removed.
+如果提供 {elanOptDef flag}`--nonexistent` 标志，则移除为当前不存在的目录配置的所有覆盖项。
+如果提供 {elanOptDef option}`--path`，则移除为 {elanMeta}`path` 设置的覆盖项。
+否则，移除当前目录的覆盖项。
 :::
 
-## Running Tools and Commands
+## 运行工具和命令
 %%%
 tag := "elan-run"
 %%%
 
-The commands in this section provide the ability to run a command in a specific toolchain and to locate a tool from a particular toolchain on disk.
-This can be useful when experimenting with different Lean versions, for cross-version testing, and for integrating Elan with other tools.
+本节中的命令可在指定工具链中运行命令，并可在磁盘上定位特定工具链中的工具。
+这适用于试验不同 Lean 版本、进行跨版本测试以及将 Elan 与其他工具集成。
 
 ```elanHelp "run"
 elan-run
@@ -553,10 +553,10 @@ DISCUSSION:
 ```
 
 :::elan run "[\"--install\"] toolchain command ..."
-Configures an environment to use the given toolchain and then runs the specified program.
-The toolchain will be installed if the {elanOptDef flag}`--install` flag is provided.
-The command may be any program; it does not need to be a command that's part of a toolchain such as `lean` or `lake`.
-This can be used for testing arbitrary toolchains without setting an override.
+配置环境以使用给定工具链，然后运行指定程序。
+如果提供 {elanOptDef flag}`--install` 标志，则会安装该工具链。
+该命令可以是任何程序，不必是 `lean` 或 `lake` 之类工具链中的命令。
+这样无需设置覆盖项即可测试任意工具链。
 :::
 
 ```elanHelp "which"
@@ -574,16 +574,16 @@ ARGS:
 ```
 
 :::elan which "command"
-Displays the full path to the toolchain-specific binary for {elanMeta}`command`.
+显示 {elanMeta}`command` 在该工具链中对应二进制文件的完整路径。
 :::
 
-## Managing Elan
+## 管理 Elan
 %%%
 tag := "elan-self"
 %%%
 
-Elan can manage its own installation.
-It can upgrade itself, remove itself, and help configure tab completion for many popular shells.
+Elan 可以管理自身的安装。
+它可以自行升级、自行卸载，并帮助为许多常用 shell 配置制表符补全。
 
 ```elanHelp "self"
 elan-self
@@ -613,11 +613,11 @@ FLAGS:
     -h, --help    Prints help information
 ```
 :::elan self update
-Downloads and installs updates to Elan itself.
+下载并安装 Elan 自身的更新。
 :::
 
 :::elan self uninstall
-Uninstalls Elan.
+卸载 Elan。
 :::
 
 ```elanHelp "completions"
@@ -737,6 +737,6 @@ DISCUSSION:
 ```
 
 :::elan completions "shell"
-Generates shell completion scripts for Elan, enabling tab completion for Elan commands in a variety of shells.
-See the output of `elan help completions` for a description of how to install them.
+为 Elan 生成 shell 补全脚本，从而在多种 shell 中启用 Elan 命令的制表符补全。
+有关安装方法的说明，请参阅 `elan help completions` 的输出。
 :::

--- a/Manual/BuildTools/Elan.lean
+++ b/Manual/BuildTools/Elan.lean
@@ -23,6 +23,7 @@ open Lean.Elab.Tactic.GuardMsgs.WhitespaceMode
 %%%
 tag := "elan"
 shortContextTitle := "Elan"
+file := "Managing-Toolchains-with-Elan"
 %%%
 
 Elan 是 Lean 工具链管理器。

--- a/Manual/BuildTools/Elan.lean
+++ b/Manual/BuildTools/Elan.lean
@@ -123,15 +123,15 @@ tag := "elan-cli"
 
 调用 Elan 时可以使用以下标志：
 
- : {elanOptDef flag}`--help` or {elanOptDef flag}`-h`
+ : {elanOptDef flag}`--help` 或 {elanOptDef flag}`-h`
 
   详细说明当前子命令。
 
- : {elanOptDef flag}`--verbose` or {elanOptDef flag}`-v`
+ : {elanOptDef flag}`--verbose` 或 {elanOptDef flag}`-v`
 
   启用详细输出。
 
- : {elanOptDef flag}`--version` or {elanOptDef flag}`-V`
+ : {elanOptDef flag}`--version` 或 {elanOptDef flag}`-V`
 
   显示 Elan 版本。
 
@@ -584,7 +584,7 @@ tag := "elan-self"
 %%%
 
 Elan 可以管理自身的安装。
-它可以自行升级、自行卸载，并帮助为许多常用 shell 配置制表符补全。
+它可以自行升级、自行卸载，并帮助为许多常用命令外壳配置制表符补全。
 
 ```elanHelp "self"
 elan-self
@@ -738,6 +738,6 @@ DISCUSSION:
 ```
 
 :::elan completions "shell"
-为 Elan 生成 shell 补全脚本，从而在多种 shell 中启用 Elan 命令的制表符补全。
+为 Elan 生成命令外壳补全脚本，从而在多种命令外壳中启用 Elan 命令的制表符补全。
 有关安装方法的说明，请参阅 `elan help completions` 的输出。
 :::

--- a/Manual/BuildTools/Lake.lean
+++ b/Manual/BuildTools/Lake.lean
@@ -40,10 +40,10 @@ Lake 是标准的 Lean 构建工具。
  * 运行测试、代码检查器及其它开发工作流
 
 Lake 是可扩展的。
-它提供了一组丰富的 API，可用于为非 Lean 编写的软件工件定义增量构建任务，以自动化管理任务并与外部工作流集成。
+它提供了一组丰富的接口，可用于为非 Lean 编写的软件工件定义增量构建任务，以自动化管理任务并与外部工作流集成。
 对于不需要这些特性的构建配置，Lake 提供了一种声明式配置语言，可以写成 TOML 或 Lean 文件。
 
-本节介绍了 Lake 的 {ref "lake-cli"}[命令行界面]、{ref "lake-config"}[配置文件] 以及 {ref "lake-api"}[内部 API]。
+本节介绍了 Lake 的 {ref "lake-cli"}[命令行界面]、{ref "lake-config"}[配置文件] 以及 {ref "lake-api"}[内部接口]。
 这三者共享了一套概念和术语。
 
 
@@ -57,7 +57,7 @@ tag := "lake-vocab"
 一个包由一个目录组成，其中包含一个 {tech (key := "package configuration")}[包配置] 文件以及源代码。
 包可以 {deftech (key := "require")}_请求_ 其他包，在这种情况下，这些包的代码（更确切地说，它们的 {tech (key := "targets")}[目标]）将变为可用状态。
 一个包的 {deftech (key := "direct dependencies")}_直接依赖_ 是它所请求的包，而 {deftech (key := "transitive dependencies")}_传递依赖_ 则是包的直接依赖及其直接依赖的传递依赖。
-包可以从 Lean 包仓库 [Reservoir](https://reservoir.lean-lang.org/){TODO}[添加章节交叉引用] 获取，或者从手动指定的位置获取。
+包可以从 Lean 包仓库 [Reservoir](https://reservoir.lean-lang.org/){TODO}[此处需添加章节交叉引用] 获取，或者从手动指定的位置获取。
 {deftech (key := "Git dependencies")}_Git 依赖_ 通过 Git 仓库 URL 及修订版本（分支、标签或哈希）指定，并在构建之前必须克隆到本地，而本地的 {deftech (key := "path dependencies")}_路径依赖_ 则通过相对于包目录的路径指定。
 
 :::paragraph
@@ -97,24 +97,24 @@ open Illuminate in
       |>.pad pad |>.frame (padding := 2) (cornerRadius := 4)
 
   let toolchain := mono "lean-toolchain"
-  let rootPkg := borderedBox "Root package" <|
+  let rootPkg := borderedBox "根包" <|
     items [
-      "Package configuration file (lakefile.lean)",
-      "Libraries",
-      "Executables",
-      "Manifest (lake-manifest.json)"
+      "包配置文件 (lakefile.lean)",
+      "库",
+      "可执行文件",
+      "清单 (lake-manifest.json)"
     ]
-  let depItems := items ["Package configuration file", "Libraries", "Executables", "Artifacts"] 8
-  let dep1 := borderedBox "Dependency 1" depItems 9 6
-  let dep2 := borderedBox "Dependency 2" depItems 9 6
+  let depItems := items ["包配置文件", "库", "可执行文件", "工件"] 8
+  let dep1 := borderedBox "依赖 1" depItems 9 6
+  let dep2 := borderedBox "依赖 2" depItems 9 6
   let dots : Diagram SVG := .text "⋯" { fontSize := 14 }
-  let packages := borderedBox "Packages" <|
+  let packages := borderedBox "包" <|
     Diagram.vsep 8 [Diagram.hsep 12 [dep1, dep2], dots] (align := .left)
-  let artifacts := borderedBox "Artifacts" <|
-    items ["Built libraries", "Built executables"]
-  let lakeDir := borderedBox "Lake Directory (.lake)" <|
+  let artifacts := borderedBox "工件" <|
+    items ["已构建的库", "已构建的可执行文件"]
+  let lakeDir := borderedBox "Lake 目录 (.lake)" <|
     Diagram.vsep 10 [packages, artifacts] (align := .left)
-  borderedBox "Workspace" <|
+  borderedBox "工作区" <|
     Diagram.vsep 10 [toolchain, rootPkg, lakeDir] (align := .left)
 
 
@@ -145,8 +145,8 @@ open Illuminate in
  * {tech (key := "Packages")}_包_ 是作为一个单元分发的 Lean 代码单元。
  * {deftech (key := "Libraries")}_库_ 是 Lean {tech (key := "module")}[模块] 的集合，在一个或多个 {deftech (key := "module roots")}_模块根_ 下按层次结构组织。
  * {deftech (key := "Executables")}_可执行文件_ 由一个定义了 `main` 的_单个_模块组成。
- * {deftech (key := "External libraries")}_外部库_ 是非 Lean 的*静态*库，它们将链接到包及其依赖的二进制文件，包括它们的共享库和可执行文件。
- * {deftech (key := "Custom targets")}_自定义目标_ 包含运行构建的任意代码，使用 Lake 的内部 API 编写。
+ * {deftech (key := "External libraries")}_外部库_ 是非 Lean 的*静态*库，它们将链接到包及依赖它的包的二进制文件，包括它们的共享库和可执行文件。
+ * {deftech (key := "Custom targets")}_自定义目标_ 包含运行构建的任意代码，使用 Lake 的内部接口编写。
 
 除了它们的 Lean 代码外，包、库和可执行文件还包含影响后续构建步骤的配置设置。
 包可以指定一组 {deftech (key := "default targets")}_默认目标_。
@@ -309,7 +309,7 @@ tag := "lake-facets"
 
 当没有显式请求分面，但指定了初始目标时，{lake}`build` 将产生初始目标的 {deftech (key := "default facet")}_默认分面_。
 每种类型的初始目标都有相应的默认分面（例如从可执行文件目标生成可执行二进制文件或构建一个包的 {tech (key := "default targets")}[默认目标]）；可以在 {tech (key := "package configuration")}[包配置] 中或通过 Lake 的 {ref "lake-cli"}[命令行界面] 显式请求其他分面。
-可以使用 Lake 的内部 API 来编写自定义分面。
+可以使用 Lake 的内部接口来编写自定义分面。
 
 
 ```lakeHelp "build"
@@ -538,7 +538,7 @@ module.transImports
 
 : `olean`
 
-  模块的 {tech (key := ".olean file")}[`.olean` 文件]。{TODO}[一旦模块系统完全落地，添加 `olean.private` 和 `olean.server` 的文档。]
+  模块的 {tech (key := ".olean file")}[`.olean` 文件]。{TODO}[模块系统完全落地后，此处需添加 `olean.private` 和 `olean.server` 的文档。]
 
 : `ilean`
 
@@ -554,7 +554,7 @@ module.transImports
 
 : `imports`
 
-  Lean 模块的直接导入，但不包含传递导入的全集。{TODO}[一旦模块系统完全落地，在此处添加 `module.importAllArts` 和 `module.importArts` 的文档。]
+  Lean 模块的直接导入，但不包含传递导入的全集。{TODO}[模块系统完全落地后，此处需添加 `module.importAllArts` 和 `module.importArts` 的文档。]
 
 : `precompileImports`
 
@@ -612,11 +612,11 @@ module.transImports
 
 : `dynlib`
 
-  共享库（例如，用于 Lean 选项 `--load-dynlib`）{TODO}[记录 Lean 命令行选项的文档，并从此处提供交叉引用]。
+  共享库（例如，用于 Lean 选项 `--load-dynlib`）{TODO}[此处需记录 Lean 命令行选项的文档，并提供交叉引用]。
 
 : `ltar`
 
-  包含模块构建工件的压缩包（通过 `leantar` 生成）。{TODO}[请同时在手册中记录 `leantar` 的文档。]
+  包含模块构建工件的压缩包（通过 `leantar` 生成）。{TODO}[此处还需在手册中补充 `leantar` 的文档。]
 
 : `linkInfoExport`
 
@@ -641,7 +641,7 @@ Lake {tech (key := "package configuration")}[包配置] 文件可包含 {deftech
 
 :::::TODO
 
-一旦能够导入足够多的 Lake 以进行精译，恢复以下内容：
+能够导入足够多的 Lake 以完成精译后，请恢复以下内容：
 
 ````
 ```lean -show
@@ -1474,7 +1474,7 @@ Lake 支持 {deftech (key := "local cache")}_本地工件缓存_，该缓存会�
 如果两个具有相同工具链的独立工作区依赖于相同的包，则它们可以共享彼此的构建产物。
 
 因为这是一项实验性功能，所以本地缓存默认处于禁用状态。
-只有当 {envVar}`LAKE_ARTIFACT_CACHE` 环境变量被设置为 `true`，或者当 {TODO}[ref] `enableArtifactCache` 字段在 {ref "lake-config"}[配置文件] 中被设置为 `true` 时才会被启用。
+只有当 {envVar}`LAKE_ARTIFACT_CACHE` 环境变量被设置为 `true`，或者当 {TODO}[交叉引用] `enableArtifactCache` 字段在 {ref "lake-config"}[配置文件] 中被设置为 `true` 时才会被启用。
 
 
 ### 远程工件缓存
@@ -1516,7 +1516,7 @@ tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Concept
 
 {include 0 Manual.BuildTools.Lake.Config}
 
-# 脚本 API 参考
+# 脚本接口参考
 %%%
 tag := "lake-api"
 %%%
@@ -1532,7 +1532,7 @@ tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Script-
 %%%
 
 提供对当前 Lake 环境信息（例如 Lean、Lake 以及其它工具的位置）访问权限的单子具备 {name Lake.MonadLakeEnv}`MonadLakeEnv` 实例。
-Lake API 中的所有单子皆是如此，包括 {name Lake.ScriptM}`ScriptM`。
+Lake 接口中的所有单子皆是如此，包括 {name Lake.ScriptM}`ScriptM`。
 
 {zhdocstring Lake.MonadLakeEnv ZhDoc.BuildTools.Lake.MonadLakeEnv}
 

--- a/Manual/BuildTools/Lake.lean
+++ b/Manual/BuildTools/Lake.lean
@@ -28,6 +28,7 @@ open Lean.Elab.Tactic.GuardMsgs.WhitespaceMode
 #doc (Manual) "Lake" =>
 %%%
 tag := "lake"
+file := "Lake"
 %%%
 
 Lake 是标准的 Lean 构建工具。
@@ -241,6 +242,9 @@ Lake 的 {deftech (key := "package overrides")}_包覆盖_ 允许将包依赖从
 :::
 
 ## 构建
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Concepts-and-Terminology--Builds"
+%%%
 
 :::paragraph
 生成所需的 {tech (key := "artifact")}[工件]，比如 {tech (key := ".olean file")}[`.olean` 文件] 或可执行二进制文件，被称为 {deftech (key := "build")}_构建_。
@@ -1433,6 +1437,9 @@ Lake 支持将构建工件（即归档后的构建目录）上传到包的 GitHu
 可以使用 {envVar}`LAKE_NO_CACHE` 环境变量来禁用此功能。
 
 ### 下载
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Concepts-and-Terminology--GitHub-Release-Builds--Downloading"
+%%%
 
 要下载工件，应配置包选项 `releaseRepo` 和 `buildArchive`，使其指向托管发布版本的 GitHub 仓库以及其中正确的工件名称（如果默认设置不充分）。
 然后，设置 `preferReleaseBuild := true`，指示 Lake 将其作为额外的包依赖项获取并解包。
@@ -1445,6 +1452,9 @@ Lake 在内部使用 `curl` 下载发布版本，并使用 `tar` 将其解包，
 该机制在技术上不仅限于 GitHub：任何使用相同 URL 方案的 Git 托管平台同样适用。
 
 ### 上传
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Concepts-and-Terminology--GitHub-Release-Builds--Uploading"
+%%%
 
 要将构建的包作为工件上传到 GitHub 发布版本，Lake 提供了 {lake}`upload` 命令作为便捷的简写。
 此命令使用 `tar` 将包的构建目录打包为归档，并使用 `gh release upload` 将其附加到指定标签下预先存在的 GitHub 发布版本中。
@@ -1479,6 +1489,9 @@ tag := "lake-cache-remote"
 它追踪源代码文件级别、{tech (key := ".olean files")}[`.olean` 文件] 以及目标代码级别的构建产物，而不是整个包级别的。
 
 ### 映射
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Concepts-and-Terminology--Artifact-Caches--Mappings"
+%%%
 
 当传递 `-o` 选项时，{lake}`build` 会追踪用于生成每个构建产物的输入。
 它们被存储为 JSON 行格式的 {deftech (key := "mappings file")}_映射文件_，文件中每一行都必须是一个有效的 JSON 对象。
@@ -1487,6 +1500,9 @@ tag := "lake-cache-remote"
 {lake}`cache put` 命令从本地缓存把映射文件中的构建产物上传到远程缓存。
 
 ### 配置
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Concepts-and-Terminology--Artifact-Caches--Configuration"
+%%%
 
 :::paragraph
 使用以下环境变量配置远程工件缓存：
@@ -1510,6 +1526,9 @@ tag := "lake-api"
 {docstring Lake.ScriptM}
 
 ## 访问环境
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Script-API-Reference--Accessing-the-Environment"
+%%%
 
 提供对当前 Lake 环境信息（例如 Lean、Lake 以及其它工具的位置）访问权限的单子具备 {name Lake.MonadLakeEnv}`MonadLakeEnv` 实例。
 Lake API 中的所有单子皆是如此，包括 {name Lake.ScriptM}`ScriptM`。
@@ -1527,6 +1546,9 @@ Lake API 中的所有单子皆是如此，包括 {name Lake.ScriptM}`ScriptM`。
 {docstring Lake.getElanToolchain}
 
 ### 搜索路径辅助函数
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Script-API-Reference--Accessing-the-Environment--Search-Path-Helpers"
+%%%
 
 {docstring Lake.getEnvLeanPath}
 
@@ -1535,6 +1557,9 @@ Lake API 中的所有单子皆是如此，包括 {name Lake.ScriptM}`ScriptM`。
 {docstring Lake.getEnvSharedLibPath}
 
 ### Elan 安装辅助函数
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Script-API-Reference--Accessing-the-Environment--Elan-Install-Helpers"
+%%%
 
 {docstring Lake.getElanInstall?}
 
@@ -1543,6 +1568,9 @@ Lake API 中的所有单子皆是如此，包括 {name Lake.ScriptM}`ScriptM`。
 {docstring Lake.getElan?}
 
 ### Lean 安装辅助函数
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Script-API-Reference--Accessing-the-Environment--Lean-Install-Helpers"
+%%%
 
 {docstring Lake.getLeanInstall}
 
@@ -1569,6 +1597,9 @@ Lake API 中的所有单子皆是如此，包括 {name Lake.ScriptM}`ScriptM`。
 {docstring Lake.getLeanCc?}
 
 ### Lake 安装辅助函数
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Script-API-Reference--Accessing-the-Environment--Lake-Install-Helpers"
+%%%
 
 {docstring Lake.getLakeInstall}
 
@@ -1581,6 +1612,9 @@ Lake API 中的所有单子皆是如此，包括 {name Lake.ScriptM}`ScriptM`。
 {docstring Lake.getLake}
 
 ## 访问工作区
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Script-API-Reference--Accessing-the-Workspace"
+%%%
 
 提供对当前 Lake 工作区信息访问权限的单子具备 {name Lake.MonadWorkspace}`MonadWorkspace` 实例。
 特别是，有针对 {name Lake.ScriptM}`ScriptM` 和 {name Lake.LakeM}`LakeM` 的实例。

--- a/Manual/BuildTools/Lake.lean
+++ b/Manual/BuildTools/Lake.lean
@@ -30,55 +30,55 @@ open Lean.Elab.Tactic.GuardMsgs.WhitespaceMode
 tag := "lake"
 %%%
 
-Lake is the standard Lean build tool.
-It is responsible for:
- * Configuring builds and building Lean code
- * Fetching and building external dependencies
- * Integrating with Reservoir, the Lean package server
- * Running tests, linters, and other development workflows
+Lake 是标准的 Lean 构建工具。
+它负责：
+ * 配置构建并构建 Lean 代码
+ * 获取并构建外部依赖
+ * 与 Reservoir（Lean 包服务器）集成
+ * 运行测试、代码检查器及其它开发工作流
 
-Lake is extensible.
-It provides a rich API that can be used to define incremental build tasks for software artifacts that are not written in Lean, to automate administrative tasks, and to integrate with external workflows.
-For build configurations that do not need these features, Lake provides a declarative configuration language that can be written either in TOML or as a Lean file.
+Lake 是可扩展的。
+它提供了一组丰富的 API，可用于为非 Lean 编写的软件工件定义增量构建任务，以自动化管理任务并与外部工作流集成。
+对于不需要这些特性的构建配置，Lake 提供了一种声明式配置语言，可以写成 TOML 或 Lean 文件。
 
-This section describes Lake's {ref "lake-cli"}[command-line interface], {ref "lake-config"}[configuration files], and {ref "lake-api"}[internal API].
-All three share a set of concepts and terminology.
+本节介绍了 Lake 的 {ref "lake-cli"}[命令行界面]、{ref "lake-config"}[配置文件] 以及 {ref "lake-api"}[内部 API]。
+这三者共享了一套概念和术语。
 
 
-# Concepts and Terminology
+# 概念与术语
 %%%
 tag := "lake-vocab"
 %%%
 
-A {deftech}_package_ is the basic unit of Lean code distribution.
-A single package may contain multiple libraries or executable programs.
-A package consist of a directory that contains a {tech}[package configuration] file together with source code.
-Packages may {deftech}_require_ other packages, in which case those packages' code (more specifically, their {tech}[targets]) are made available.
-The {deftech}_direct dependencies_ of a package are those that it requires, and the {deftech}_transitive dependencies_ are the direct dependencies of a package together with their transitive dependencies.
-Packages may either be obtained from [Reservoir](https://reservoir.lean-lang.org/){TODO}[xref chapter], the Lean package repository, or from a manually-specified location.
-{deftech}_Git dependencies_ are specified by a Git repository URL along with a revision (branch, tag, or hash) and must be cloned locally prior to build, while local {deftech}_path dependencies_ are specified by a path relative to the package's directory.
+{deftech (key := "package")}_包_ 是 Lean 代码分发的基本单位。
+一个包可以包含多个库或可执行程序。
+一个包由一个目录组成，其中包含一个 {tech (key := "package configuration")}[包配置] 文件以及源代码。
+包可以 {deftech (key := "require")}_请求_ 其他包，在这种情况下，这些包的代码（更确切地说，它们的 {tech (key := "targets")}[目标]）将变为可用状态。
+一个包的 {deftech (key := "direct dependencies")}_直接依赖_ 是它所请求的包，而 {deftech (key := "transitive dependencies")}_传递依赖_ 则是包的直接依赖及其直接依赖的传递依赖。
+包可以从 Lean 包仓库 [Reservoir](https://reservoir.lean-lang.org/){TODO}[添加章节交叉引用] 获取，或者从手动指定的位置获取。
+{deftech (key := "Git dependencies")}_Git 依赖_ 通过 Git 仓库 URL 及修订版本（分支、标签或哈希）指定，并在构建之前必须克隆到本地，而本地的 {deftech (key := "path dependencies")}_路径依赖_ 则通过相对于包目录的路径指定。
 
 :::paragraph
-A {deftech}_workspace_ is a directory on disk that contains a working copy of a {tech}[package]'s source code and the source code of all {tech}[transitive dependencies] that are not specified as local paths.
-The package for which the workspace was created is the {deftech}_root package_.
-The workspace also contains any built {tech}[artifacts] for the package, enabling {tech}[incremental builds].
-Dependencies and artifacts do not need to be present for a directory to be considered a workspace; commands such as {lake}`update` and {lake}`build` produce them if they are missing.
-Lake is typically used in a workspace.{margin}[{lake}`init` and {lake}`new`, which create workspaces, are exceptions.]
-Workspaces typically have the following layout:
+{deftech (key := "workspace")}_工作区_ 是磁盘上的一个目录，包含一个 {tech (key := "package")}[包] 的源代码工作副本，以及所有未指定为本地路径的 {tech (key := "transitive dependencies")}[传递依赖] 的源代码。
+为其创建工作区的包即为 {deftech (key := "root package")}_根包_。
+工作区还包含为该包构建的任何 {tech (key := "artifacts")}[工件]，从而支持 {tech (key := "incremental builds")}[增量构建]。
+一个目录要被视为工作区，并不需要预先存在依赖和工件；如果它们缺失，诸如 {lake}`update` 和 {lake}`build` 这样的命令会生成它们。
+Lake 通常在工作区中使用。{margin}[创建工作区的 {lake}`init` 和 {lake}`new` 是例外。]
+工作区通常具有以下布局：
 
- * `lean-toolchain`: The {tech}[toolchain file].
- * `lakefile.toml` or `lakefile.lean`: The {tech}[package configuration] file for the root package.
- * `lake-manifest.json`: The root package's {tech}[manifest].
- * `.lake/`: Intermediate state managed by Lake, such as built {tech}[artifacts] and dependency source code.
-   * `.lake/lakefile.olean`: The root package's configuration, cached.
-   * `.lake/packages/`: The workspace's {deftech}_package directory_, which contains copies of all non-local transitive dependencies of the root package, with their built artifacts in their own `.lake` directories.
-   * `.lake/build/`: The {deftech}_build directory_, which contains built artifacts for the root package:
-     * `.lake/build/bin`: The package's {deftech}_binary directory_, which contains built executables.
-     * `.lake/build/lib`: The package's _library directory_, which contains built libraries and {tech}[`.olean` files].
-     * `.lake/build/ir`: The package's intermediate result directory, which contains generated intermediate artifacts, primarily C code.
+ * `lean-toolchain`：{tech (key := "toolchain file")}[工具链文件]。
+ * `lakefile.toml` 或 `lakefile.lean`：根包的 {tech (key := "package configuration")}[包配置] 文件。
+ * `lake-manifest.json`：根包的 {tech (key := "manifest")}[清单]。
+ * `.lake/`：Lake 管理的中间状态，例如已构建的 {tech (key := "artifacts")}[工件] 和依赖源代码。
+   * `.lake/lakefile.olean`：根包的配置（已缓存）。
+   * `.lake/packages/`：工作区的 {deftech (key := "package directory")}_包目录_，其中包含根包的所有非本地传递依赖的副本，并在它们各自的 `.lake` 目录中包含已构建的工件。
+   * `.lake/build/`：{deftech (key := "build directory")}_构建目录_，其中包含根包的已构建工件：
+     * `.lake/build/bin`：包的 {deftech (key := "binary directory")}_二进制目录_，其中包含已构建的可执行文件。
+     * `.lake/build/lib`：包的 _库目录_，其中包含已构建的库和 {tech (key := ".olean files")}[`.olean` 文件]。
+     * `.lake/build/ir`：包的中间结果目录，其中包含生成的中间工件，主要是 C 代码。
 :::
 
-:::figure "Workspace Layout" (tag :="workspace-layout")
+:::figure "工作区布局" (tag :="workspace-layout")
 ```diagram
 open Illuminate in
   let txt (s : String) (size : Float := 10) : Diagram SVG :=
@@ -120,81 +120,81 @@ open Illuminate in
 :::
 
 :::paragraph
-A {deftech}_package configuration_ file specifies the dependencies, settings, and targets of a package.
-Packages can specify configuration options that apply to all their contained targets.
-They can be written in two formats:
- * The {ref "lake-config-toml"}[TOML format] (`lakefile.toml`) is used for fully declarative package configurations.
- * The {ref "lake-config-lean"}[Lean format] (`lakefile.lean`) additionally supports the use of Lean code to configure the package in ways not supported by the declarative options.
+{deftech (key := "package configuration")}_包配置_ 文件指定了一个包的依赖、设置和目标。
+包可以指定适用于其包含的所有目标的配置选项。
+它们可以用两种格式编写：
+ * {ref "lake-config-toml"}[TOML 格式]（`lakefile.toml`）用于完全声明式的包配置。
+ * {ref "lake-config-lean"}[Lean 格式]（`lakefile.lean`）另外支持使用 Lean 代码来以声明式选项不支持的方式配置包。
 :::
 
-A {deftech}_manifest_ tracks the specific versions of other packages that are used in a package.
-Together, a manifest and a {tech}[package configuration] file specify a unique set of transitive dependencies for the package.
-Before building, Lake synchronizes the local copy of each dependency with the version specified in the manifest.
-If no manifest is available, Lake fetches the latest matching versions of each dependency and creates a manifest.
-It is an error if the package names listed in the manifest do not match those used by the package; the manifest must be updated using {lake}`update` prior to building.
-Manifests should be considered part of the package's code and should normally be checked into source control.
+{deftech (key := "manifest")}_清单_ 追踪包中使用的其他包的特定版本。
+清单和 {tech (key := "package configuration")}[包配置] 文件共同为一个包指定了唯一的一组传递依赖。
+在构建之前，Lake 会将每个依赖的本地副本与清单中指定的版本同步。
+如果没有可用的清单，Lake 会获取每个依赖的最新匹配版本并创建一个清单。
+如果清单中列出的包名与包所使用的名称不匹配，则会报错；在构建之前必须使用 {lake}`update` 更新清单。
+清单应被视为包代码的一部分，通常应检入版本控制系统。
 
 :::paragraph
-A {deftech}_target_ represents an output that can be requested by a user.
-A persistent build output, such as object code, an executable binary, or an {tech}[`.olean` file], is called an {deftech}_artifact_.
-In the process of producing an artifact, Lake may need to produce further artifacts; for example, compiling a Lean program into an executable requires that it and its dependencies be compiled to object files, which are themselves produced from C source files, which result from elaborating Lean sourcefiles and producing {tech}[`.olean` files].
-Each link in this chain is a target, and Lake arranges for each to be built in turn.
-At the start of the chain are the {deftech}_initial targets_:
- * {tech}_Packages_ are units of Lean code that are distributed as a unit.
- * {deftech}_Libraries_ are collections of Lean {tech}[module]s, organized hierarchically under one or more {deftech}_module roots_.
- * {deftech}_Executables_ consist of a _single_ module that defines `main`.
- * {deftech}_External libraries_ are non-Lean *static* libraries that will be linked to the binaries of the package and its dependents, including both their shared libraries and executables.
- * {deftech}_Custom targets_ contain arbitrary code to run a build, written using Lake's internal API.
+{deftech (key := "target")}_目标_ 表示用户可以请求的输出。
+持久的构建输出，例如目标代码、可执行二进制文件或 {tech (key := ".olean file")}[`.olean` 文件]，被称为 {deftech (key := "artifact")}_工件_。
+在生成工件的过程中，Lake 可能需要生成进一步的工件；例如，将 Lean 程序编译为可执行文件要求它及其依赖被编译为目标文件，而这些文件本身是从 C 源文件生成的，C 源文件则是通过对 Lean 源文件进行推导并生成 {tech (key := ".olean files")}[`.olean` 文件] 得出的。
+该链条中的每个环节都是一个目标，Lake 会安排它们依次构建。
+处于链条起点的是 {deftech (key := "initial targets")}_初始目标_：
+ * {tech (key := "Packages")}_包_ 是作为一个单元分发的 Lean 代码单元。
+ * {deftech (key := "Libraries")}_库_ 是 Lean {tech (key := "module")}[模块] 的集合，在一个或多个 {deftech (key := "module roots")}_模块根_ 下按层次结构组织。
+ * {deftech (key := "Executables")}_可执行文件_ 由一个定义了 `main` 的_单个_模块组成。
+ * {deftech (key := "External libraries")}_外部库_ 是非 Lean 的*静态*库，它们将链接到包及其依赖的二进制文件，包括它们的共享库和可执行文件。
+ * {deftech (key := "Custom targets")}_自定义目标_ 包含运行构建的任意代码，使用 Lake 的内部 API 编写。
 
-In addition to their Lean code, packages, libraries, and executables contain configuration settings that affect subsequent build steps.
-Packages may specify a set of {deftech}_default targets_.
-Default targets are the initial targets in the package that are to be built in contexts where a package is specified but specific targets are not.
+除了它们的 Lean 代码外，包、库和可执行文件还包含影响后续构建步骤的配置设置。
+包可以指定一组 {deftech (key := "default targets")}_默认目标_。
+默认目标是包中要在指定了包但未指定特定目标的上下文中构建的初始目标。
 :::
 
 :::paragraph
-The {deftech}_log_ contains information produced during a build.
-Logs are saved so they can be replayed during {tech}[incremental builds].
-Messages in the log have four levels, ordered by severity:
+{deftech (key := "log")}_日志_ 包含在构建期间生成的信息。
+保存日志是为了在 {tech (key := "incremental builds")}[增量构建] 期间进行重放。
+日志中的消息按严重程度分为四个级别：
 
- 1. _Trace messages_ contain internal build details that are often specific to the machine on which the build is running, including the specific invocations of Lean and other tools that are passed to the shell.
- 2. _Informational messages_ contain general informational output that is not expected to indicate a problem with the code, such as the results of a {keywordOf Lean.Parser.Command.eval}`#eval` command.
- 3. _Warnings_ indicate potential problems, such as unused variable bindings.
- 4. _Errors_ explain why parsing and elaboration could not complete.
+ 1. _追踪消息_包含通常特定于运行构建的机器的内部构建详细信息，包括传递给命令外壳的 Lean 及其他工具的具体调用。
+ 2. _信息性消息_包含通常不表示代码有问题的常规信息输出，例如 {keywordOf Lean.Parser.Command.eval}`#eval` 命令的结果。
+ 3. _警告_指出潜在问题，例如未使用的变量绑定。
+ 4. _错误_解释为什么解析和推导无法完成。
 
-By default, trace messages are hidden and the others are shown.
-The threshold can be adjusted using the {lakeOpt}`--log-level` option, the {lakeOpt}`--verbose` flag, or the {lakeOpt}`--quiet` flag.
+默认情况下，追踪消息被隐藏，其他的被显示。
+阈值可以通过 {lakeOpt}`--log-level` 选项、{lakeOpt}`--verbose` 标志或 {lakeOpt}`--quiet` 标志进行调整。
 :::
 
-## Package  Overrides
+## 包覆盖
 %%%
 tag := "package-overrides"
 %%%
 
-Together, the {tech}[package configuration] and {tech}[manifest] describe the exact manner by which Lake expects to acquire dependencies.
-Usually, this involves making a local copy of a remote Git repository over the network.
-Lake terminates with an error if the remote repository cannot be accessed.
-Because the sources of dependencies are predictable, builds are reproducible across systems; packages are retrieved in the same way from the same sources on all machines.
+{tech (key := "package configuration")}[包配置] 和 {tech (key := "manifest")}[清单] 共同描述了 Lake 获取依赖的精确方式。
+通常，这涉及通过网络从远程 Git 仓库获取本地副本。
+如果无法访问远程仓库，Lake 会终止并报错。
+因为依赖来源是可预测的，所以跨系统的构建是可重现的；在所有机器上都从相同来源以相同方式检索包。
 
-Nonetheless, there are situations where it is infeasible to acquire package dependencies the same way the original developers did.
-For example, some companies require that all dependencies are audited prior to use, and not everyone always has access to the Internet while working.
-In these situations, it is necessary to acquire packages in some other way.
+尽管如此，仍存在无法采用与原始开发者相同的方式获取包依赖的情况。
+例如，有些公司要求所有依赖在使用前都须经过审计，而且并不是每个人在工作时都能一直连接互联网。
+在这些情况下，就有必要通过其他方式获取包。
 
-Lake's {deftech}_package overrides_ allow a package dependency to be redirected from one source to another without modifying any {tech}[package configurations] or {tech}[manifests].
-They do not allow packages to be added to or removed from the {tech}[workspace].
-All transitive dependencies in the workspace respect the redirection.
-The package overrides file is a JSON file that contains an alternate list of package entries.
-These entries will take precedence over those in the package's {tech}[manifest].
-This file can be provided to Lake either via the {lakeOpt}`--packages` option or by placing it at a fixed path within the Lake workspace: `.lake/package-overrides.json`.
+Lake 的 {deftech (key := "package overrides")}_包覆盖_ 允许将包依赖从一个源重定向到另一个源，而无需修改任何 {tech (key := "package configurations")}[包配置] 或 {tech (key := "manifests")}[清单]。
+它们不允许在 {tech (key := "workspace")}[工作区] 中添加或移除包。
+工作区中所有的传递依赖都遵守重定向。
+包覆盖文件是一个 JSON 文件，包含包条目的备用列表。
+这些条目将优先于包的 {tech (key := "manifest")}[清单] 中的条目。
+可以通过 {lakeOpt}`--packages` 选项，或者将其放置在 Lake 工作区内的固定路径 `.lake/package-overrides.json`，来将此文件提供给 Lake。
 
-The syntax of package entries in the package overrides file mirrors that of the {tech}[manifest].
-Thus, it is possible to copy an entry from a manifest into a package overrides file (and vice versa).
-One way to determine the necessary syntax for a package entry is to add a temporary dependency to a {tech}[package configuration] that matches the desired configuration, run {lake}`update` to generate a manifest with that dependency, and then copy the entry from the manifest into the package overrides file.
+包覆盖文件中的包条目语法与 {tech (key := "manifest")}[清单] 的语法一致。
+因此，可以把清单中的条目复制到包覆盖文件中（反之亦然）。
+确定包条目所需语法的一种方法是：向 {tech (key := "package configuration")}[包配置] 中添加匹配所需配置的临时依赖，运行 {lake}`update` 以生成包含该依赖的清单，然后将清单中的条目复制到包覆盖文件中。
 
-:::example "Making Remote Dependencies Local"
+:::example "本地化远程依赖" (file := "Making Remote Dependencies Local")
 
-Consider a use case where programs are being developed in a restricted enviroment without network access (e.g., for security reasons).
-The team wishes to compile a small tool written in Lean that depends on the [`@leanprover/Cli`](https://reservoir.lean-lang.org/@leanprover/Cli) library to provide a simple command-line interface.
-That tool's {tech}[manifest] thus looks something like this:
+考虑这样一个用例：在受限环境（例如出于安全原因）中开发程序，且没有网络连接。
+团队希望编译一个用 Lean 编写的依赖于 [`@leanprover/Cli`](https://reservoir.lean-lang.org/@leanprover/Cli) 库来提供简单命令行界面的小工具。
+该工具的 {tech (key := "manifest")}[清单] 因此如下所示：
 
 ```lakeManifest
 {
@@ -218,9 +218,9 @@ That tool's {tech}[manifest] thus looks something like this:
 }
 ```
 
-This manifest would instruct Lake to download the `Cli` package from the indicated GitHub URL when building this tool.
-However, the restricted environment does not have network access, so the build will fail unless Lake uses a local copy instead.
-This can be done with the following {tech}[package overrides] file:
+该清单将指示 Lake 在构建此工具时从指定的 GitHub URL 下载 `Cli` 包。
+但是，由于受限环境没有网络连接，如果不使用本地副本，构建将会失败。
+这可以通过以下 {tech (key := "package overrides")}[包覆盖] 文件完成：
 
 ```lakePackageOverrides
 {
@@ -236,75 +236,75 @@ This can be done with the following {tech}[package overrides] file:
 }
 ```
 
-With this, Lake will instead resolve the `Cli` dependency to the local package located at the path `/etc/lean-packages/Cli`.
+有了这个文件，Lake 将把 `Cli` 依赖解析为位于路径 `/etc/lean-packages/Cli` 的本地包。
 
 :::
 
-## Builds
+## 构建
 
 :::paragraph
-Producing a desired {tech}[artifact], such as a {tech}[`.olean` file] or an executable binary, is called a {deftech}_build_.
-Builds are triggered by the {lake}`build` command or by other commands that require an artifact to be present, such as {lake}`exe`.
-A build consists of the following steps:
+生成所需的 {tech (key := "artifact")}[工件]，比如 {tech (key := ".olean file")}[`.olean` 文件] 或可执行二进制文件，被称为 {deftech (key := "build")}_构建_。
+构建由 {lake}`build` 命令或需要工件存在的其他命令（例如 {lake}`exe`）触发。
+构建包括以下步骤：
 
-: {deftech (key := "configure package")}[Configuring] the package
+: {deftech (key := "configure package")}[配置包]
 
-  If {tech}[package configuration] file is newer than the cached configuration file `lakefile.olean`, then the package configuration is re-elaborated.
-  This also occurs when the cached file is missing or when the {lakeOpt}`--reconfigure` or {lakeOpt}`-R` flag is provided.
-  Changes to options using {lakeOpt}`-K` do not trigger re-elaboration of the configuration file; {lakeOpt}`-R` is necessary in these cases.
+  如果 {tech (key := "package configuration")}[包配置] 文件比缓存的配置文件 `lakefile.olean` 更新，那么包配置就会被重新推导。
+  当缓存文件缺失或者提供了 {lakeOpt}`--reconfigure` 或 {lakeOpt}`-R` 标志时，也会发生这种情况。
+  使用 {lakeOpt}`-K` 对选项的更改不会触发配置文件的重新推导；在这些情况下，必须使用 {lakeOpt}`-R`。
 
-: Computing dependencies
+: 计算依赖
 
-  The set of artifacts that are required to produce the desired output are determined, along with the {tech}[targets] and {tech}[facets] that produce them.
-  This process is recursive, and the result is a _graph_ of dependencies.
-  The dependencies in this graph are distinct from those declared for a package: packages depend on other packages, while build targets depend on other build targets, which may be in the same package or in a different one.
-  One facet of a given target may depend on other facets of the same target.
-  Lake automatically analyzes the imports of Lean modules to discover their dependencies, and the {tomlField Lake.LeanLibConfig}`extraDepTargets` field can be used to add additional dependencies to a target.
+  确定产生所需输出所需的工件集，以及产生它们的 {tech (key := "targets")}[目标] 和 {tech (key := "facets")}[分面]。
+  该过程是递归的，结果是一个依赖_图_。
+  图中的依赖与为包声明的依赖不同：包依赖于其他包，而构建目标依赖于其他构建目标，它们可能位于同一个包中，也可能位于不同的包中。
+  给定目标的一个分面可能依赖于同一目标的其他分面。
+  Lake 会自动分析 Lean 模块的导入以发现它们的依赖，并且可使用 {tomlField Lake.LeanLibConfig}`extraDepTargets` 字段向目标添加额外的依赖。
 
-: Replaying traces
+: 重放追踪
 
-  Rather than rebuilding everything in the dependency graph from scratch, Lake uses saved {deftech}_trace files_ to determine which artifacts require building.
-  During a build, Lake records which source files or other artifacts were used to produce each artifact, saving a hash of each input; these {deftech}_traces_ are saved in the {tech}[build directory].{margin}[More specifically, each artifact's trace file contains a Merkle tree hash mixture of its inputs' hashes.]
-  If the inputs are all unmodified, then the corresponding artifact is not rebuilt.
-  Trace files additionally record the {tech}[log] from each build task; these outputs are replayed as if the artifact had been built anew.
-  Reusing prior build products when possible is called an {deftech}_incremental build_.
+  Lake 不会从头开始重建依赖图中的所有内容，而是使用保存的 {deftech (key := "trace files")}_追踪文件_ 来确定哪些工件需要构建。
+  在构建期间，Lake 会记录用于生成每个工件的源文件或其他工件，保存每个输入的哈希；这些 {deftech (key := "traces")}_追踪_ 保存在 {tech (key := "build directory")}[构建目录] 中。{margin}[更具体地说，每个工件的追踪文件包含其输入哈希值的 Merkle 树哈希混合。]
+  如果所有输入均未修改，则不再重新构建相应的工件。
+  追踪文件还额外记录了每个构建任务的 {tech (key := "log")}[日志]；这些输出会被重放，就好像工件被重新构建一样。
+  在可能的情况下重用先前的构建产物被称为 {deftech (key := "incremental build")}_增量构建_。
 
-: Building artifacts
+: 构建工件
 
-  When all unmodified dependencies in the dependency graph have been replayed from their trace files, Lake proceeds to build each artifact.
-  This involves running the appropriate build tool on the input files and saving the artifact and its trace file, as specified in the corresponding facet.
+  当依赖图中所有未修改的依赖都从它们的追踪文件中重放后，Lake 会继续构建每个工件。
+  这涉及在输入文件上运行适当的构建工具，并按对应分面的指定，保存工件及其追踪文件。
 :::
 
-Lake uses two separate hash algorithms.
-Text files are hashed after normalizing newlines, so that files that differ only by platform-specific newline conventions are hashed identically.
-Other files are hashed without any normalization.
+Lake 使用两种不同的哈希算法。
+文本文件在规范化换行符之后再进行哈希处理，以便仅因平台特定的换行约定不同而不同的文件也能生成相同的哈希值。
+其他文件在哈希时则不作任何规范化。
 
-Along with the trace files, Lean caches input hashes.
-Whenever an artifact is built, its hash is saved in a separate file that can be re-read instead of computing the hash from scratch.
-This is a performance optimization.
-This feature can be disabled, causing all hashes to be recomputed from their inputs, using the {lakeOpt}`--rehash` command-line option.
+与追踪文件一样，Lean 会缓存输入哈希。
+每当构建一个工件时，其哈希值都会保存在一个独立的文件中，这样可以直接读取该文件，而无需从头计算哈希值。
+这是一种性能优化。
+可以通过 {lakeOpt}`--rehash` 命令行选项禁用此功能，导致所有哈希值都由其输入重新计算。
 
 :::paragraph
-During a build, the following directories are provided to the underlying build tools:
- * The {deftech}_source directory_ contains Lean source code that is available for import.
- * The {deftech}_library directories_ contain {tech}[`.olean` files] along with the shared and static libraries that are available for linking; it normally consists of the {tech}[root package]'s library directory (found in `.lake/build/lib`), the library directories for the other packages in the workspace, the library directory for the current Lean toolchain, and the system library directory.
- * The {deftech}_Lake home_ is the directory in which Lake is installed, including binaries, source code, and libraries.
-   The libraries in the Lake home are needed to elaborate Lake configuration files, which have access to the full power of Lean.
+在构建期间，会向底层构建工具提供以下目录：
+ * {deftech (key := "source directory")}_源码目录_ 包含可供导入的 Lean 源代码。
+ * {deftech (key := "library directories")}_库目录_ 包含 {tech (key := ".olean files")}[`.olean` 文件] 以及可用于链接的共享库和静态库；它通常由 {tech (key := "root package")}[根包] 的库目录（在 `.lake/build/lib` 下）、工作区中其他包的库目录、当前 Lean 工具链的库目录以及系统库目录组成。
+ * {deftech (key := "Lake home")}_Lake 主目录_ 是安装 Lake 的目录，包含二进制文件、源代码和库。
+   Lake 目录中的库在推导 Lake 配置文件时不可或缺，这样配置文件就能访问 Lean 的全部功能。
 :::
 
-## Facets
+## 分面
 %%%
 tag := "lake-facets"
 %%%
 
-A {deftech}_facet_ describes the production of a target from another.
-Conceptually, any target may have facets.
-However, executables, external libraries, and custom targets provide only a single implicit facet.
-Packages, libraries, and modules have multiple facets that can be requested by name when invoking {lake}`build` to select the corresponding target.
+{deftech (key := "facet")}_分面_ 描述了一个目标从另一个目标的生产过程。
+从概念上讲，任何目标都可以拥有分面。
+然而，可执行文件、外部库和自定义目标只提供单一的隐式分面。
+包、库和模块拥有多个分面，调用 {lake}`build` 选定相应目标时，可以通过名称请求它们。
 
-When no facet is explicitly requested, but an initial target is designated, {lake}`build` produces the initial target's {deftech}_default facet_.
-Each type of initial target has a corresponding default facet (e.g. producing an executable binary from an executable target or building a package's {tech}[default targets]); other facets may be explicitly requested in the {tech}[package configuration] or via Lake's {ref "lake-cli"}[command-line interface].
-Lake's internal API may be used to write custom facets.
+当没有显式请求分面，但指定了初始目标时，{lake}`build` 将产生初始目标的 {deftech (key := "default facet")}_默认分面_。
+每种类型的初始目标都有相应的默认分面（例如从可执行文件目标生成可执行二进制文件或构建一个包的 {tech (key := "default targets")}[默认目标]）；可以在 {tech (key := "package configuration")}[包配置] 中或通过 Lake 的 {ref "lake-cli"}[命令行界面] 显式请求其他分面。
+可以使用 Lake 的内部 API 来编写自定义分面。
 
 
 ```lakeHelp "build"
@@ -366,10 +366,10 @@ mappings can then be used to upload build artifacts to a remote cache with
 
 ::::paragraph
 
-The facets available for packages are:
+包可用的分面有：
 
 ```lean -show
--- Always keep this in sync with the description below. It ensures that the list is complete.
+-- 始终使之与下方描述保持同步。这确保了列表是完整的。
 /--
 info: #[`package.barrel, `package.cache, `package.deps, `package.extraDep, `package.optBarrel, `package.optCache,
   `package.optRelease, `package.release, `package.transDeps]
@@ -379,52 +379,52 @@ info: #[`package.barrel, `package.cache, `package.deps, `package.extraDep, `pack
 ```
 : `extraDep`
 
-  The default facets of the package's extra dependency targets, specified in the {tomlField Lake.PackageConfig}`extraDepTargets` field.
+  包在 {tomlField Lake.PackageConfig}`extraDepTargets` 字段中指定的额外依赖目标的默认分面。
 
 : `deps`
 
-  The package's {tech}[direct dependencies].
+  包的 {tech (key := "direct dependencies")}[直接依赖]。
 
 : `transDeps`
 
-  The package's {tech}[transitive dependencies], topologically sorted.
+  包经过拓扑排序的 {tech (key := "transitive dependencies")}[传递依赖]。
 
 
 : `optCache`
 
-  A package's optional cached build archive (e.g., from Reservoir or GitHub).
-  Will *not* cause the whole build to fail if the archive cannot be fetched.
+  包可选的缓存构建归档（例如，来自 Reservoir 或 GitHub）。
+  如果无法获取归档，*不会*导致整个构建失败。
 
 : `cache`
 
-  A package's cached build archive (e.g., from Reservoir or GitHub).
-  Will cause the whole build to fail if the archive cannot be fetched.
+  包的缓存构建归档（例如，来自 Reservoir 或 GitHub）。
+  如果无法获取归档，将导致整个构建失败。
 
 : `optBarrel`
 
-  A package's optional cached build archive (e.g., from Reservoir or GitHub).
-  Will *not* cause the whole build to fail if the archive cannot be fetched.
+  包可选的缓存构建归档（例如，来自 Reservoir 或 GitHub）。
+  如果无法获取归档，*不会*导致整个构建失败。
 
 : `barrel`
 
-  A package's cached build archive (e.g., from Reservoir or GitHub).
-  Will cause the whole build to fail if the archive cannot be fetched.
+  包的缓存构建归档（例如，来自 Reservoir 或 GitHub）。
+  如果无法获取归档，将导致整个构建失败。
 
 : `optRelease`
 
-  A package's optional build archive from a GitHub release.
-  Will *not* cause the whole build to fail if the release cannot be fetched.
+  来自 GitHub 发布版本的包可选构建归档。
+  如果无法获取发布版本，*不会*导致整个构建失败。
 
 : `release`
 
-  A package's build archive from a GitHub release.
-  Will cause the whole build to fail if the archive cannot be fetched.
+  来自 GitHub 发布版本的包构建归档。
+  如果无法获取归档，将导致整个构建失败。
 
 
 ::::
 
 ```lean -show
--- Always keep this in sync with the description below. It ensures that the list is complete.
+-- 始终使之与下方描述保持同步。这确保了列表是完整的。
 /--
 info: [`lean_lib.extraDep, `lean_lib.leanArts, `lean_lib.static.export, `lean_lib.shared, `lean_lib.modules, `lean_lib.static,
   `lean_lib.default]
@@ -435,38 +435,38 @@ info: [`lean_lib.extraDep, `lean_lib.leanArts, `lean_lib.static.export, `lean_li
 
 :::paragraph
 
-The facets available for libraries are:
+库可用的分面有：
 
 : `leanArts`
 
-  The artifacts that the Lean compiler produces for the library or executable ({tech (key := ".olean files")}`*.olean`, `*.ilean`, and `*.c` files).
+  Lean 编译器为库或可执行文件生成的工件（{tech (key := ".olean files")}`*.olean`、`*.ilean` 和 `*.c` 文件）。
 
 : `static`
 
-  The static library produced by the C compiler from the `leanArts` (that is, a `*.a` file).
+  由 C 编译器从 `leanArts` 生成的静态库（即 `*.a` 文件）。
 
 : `static.export`
 
-  The static library produced by the C compiler from the `leanArts` (that is, a `*.a` file), with exported symbols.
+  由 C 编译器从 `leanArts` 生成的具有导出符号的静态库（即 `*.a` 文件）。
 
 : `shared`
 
-  The shared library produced by the C compiler from the `leanArts` (that is, a `*.so`, `*.dll`, or `*.dylib` file, depending on the platform).
+  由 C 编译器从 `leanArts` 生成的共享库（取决于平台，即 `*.so`、`*.dll` 或 `*.dylib` 文件）。
 
 : `extraDep`
 
-  A Lean library's {tomlField Lake.LeanLibConfig}`extraDepTargets` and those of its package.
+  Lean 库及其所属包的 {tomlField Lake.LeanLibConfig}`extraDepTargets`。
 
 :::
 
 :::paragraph
 
-Executables have a single `exe` facet that consists of the executable binary.
+可执行文件只有一个由可执行二进制文件组成的 `exe` 分面。
 
 :::
 
 ```lean -show
--- Always keep this in sync with the description below. It ensures that the list is complete.
+-- 始终使之与下方描述保持同步。这确保了列表是完整的。
 /--
 info: module.bc
 module.bc.o
@@ -509,134 +509,134 @@ module.transImports
 ```
 
 :::paragraph
-The facets available for modules are:
+模块可用的分面有：
 
 : `lean`
 
-  The module's Lean source file.
+  模块的 Lean 源文件。
 
-: `leanArts` (default)
+: `leanArts`（默认）
 
- The module's Lean artifacts (`*.olean`, `*.ilean`, `*.c` files).
+  模块的 Lean 工件（`*.olean`、`*.ilean`、`*.c` 文件）。
 
 : `deps`
 
-  The module's dependencies (e.g., imports or shared libraries).
+  模块的依赖（例如导入或共享库）。
 
 : `depHash`
 
-  A hash of a module's build dependencies (e.g., imports, source, plugins).
+  模块的构建依赖（例如，导入、源码、插件）的哈希。
 
 : `depTrace`
 
-  A Lake build trace data structure (i.e., composite hash and modification time) of a module's build dependencies (e.g., imports, source, plugins).
+  包含模块的构建依赖（例如，导入、源码、插件）的 Lake 构建追踪数据结构（即复合哈希与修改时间）。
 
 : `olean`
 
- The module's {tech}[`.olean` file]. {TODO}[Once module system lands fully, add docs for `olean.private` and `olean.server`]
+  模块的 {tech (key := ".olean file")}[`.olean` 文件]。{TODO}[一旦模块系统完全落地，添加 `olean.private` 和 `olean.server` 的文档。]
 
 : `ilean`
 
- The module's `.ilean` file, which is metadata used by the Lean language server.
+  模块的 `.ilean` 文件，即 Lean 语言服务器使用的元数据。
 
 : `header`
 
-  The parsed module header of the module's source file.
+  模块源文件中解析出的模块头部。
 
 : `input`
 
-  The module's processed Lean source file. Combines tracing the file with parsing its header.
+  模块处理过的 Lean 源文件。结合了对文件的追踪与头部的解析。
 
 : `imports`
 
-  The immediate imports of the Lean module, but not the full set of transitive imports. {TODO}[Once the module system lands fully, add docs here for `module.importAllArts`, `module.importArts`]
+  Lean 模块的直接导入，但不包含传递导入的全集。{TODO}[一旦模块系统完全落地，在此处添加 `module.importAllArts` 和 `module.importArts` 的文档。]
 
 : `precompileImports`
 
-  The transitive imports of the Lean module, compiled to object code.
+  Lean 模块的传递导入，编译为目标代码。
 
 : `transImports`
 
-  The transitive imports of the Lean module, as {tech}[`.olean` files].
+  作为 {tech (key := ".olean files")}[`.olean` 文件] 的 Lean 模块传递导入。
 
 : `allImports`
 
-  Both the immediate and transitive imports of the Lean module.
+  Lean 模块的直接导入和传递导入。
 
 : `setup`
 
-  All of a module's dependencies: transitive local imports and shared libraries to be loaded with `--load-dynlib`.
-  Returns the list of shared libraries to load along with their search path.
+  模块的所有依赖：使用 `--load-dynlib` 加载的传递本地导入和共享库。
+  返回要加载的共享库列表及其搜索路径。
 
 : `ir`
 
-  The `.ir` file produced for modules that use the {ref "module-structure"}[module system].
+  为使用 {ref "module-structure"}[模块系统] 的模块生成的 `.ir` 文件。
 
 
 : `ir.sig`
 
-  The `.ir.sig` file produced for modules that use the {ref "module-structure"}[module system].
+  为使用 {ref "module-structure"}[模块系统] 的模块生成的 `.ir.sig` 文件。
 
 : `c`
 
- The C file produced by the Lean compiler.
+  由 Lean 编译器生成的 C 文件。
 
 : `bc`
 
- LLVM bitcode file, produced by the Lean compiler.
+  由 Lean 编译器生成的 LLVM 位码文件。
 
 : `c.o`
 
- The compiled object file, produced from the C file. On Windows, this is equivalent to `.c.o.noexport`, while it is equivalent to `.c.o.export` on other platforms.
+  由 C 文件生成的编译目标文件。在 Windows 上它等同于 `.c.o.noexport`，而在其他平台上它等同于 `.c.o.export`。
 
 : `c.o.export`
 
- The compiled object file, produced from the C file, with Lean symbols exported.
+  由 C 文件生成的编译目标文件，其中导出了 Lean 符号。
 
 : `c.o.noexport`
 
- The compiled object file, produced from the C file, without Lean symbols exported.
+  由 C 文件生成的编译目标文件，其中未导出 Lean 符号。
 
 : `bc.o`
 
- The compiled object file, produced from the LLVM bitcode file.
+  由 LLVM 位码文件生成的编译目标文件。
 
 : `o`
 
- The compiled object file for the configured backend.
+  为配置的后端生成的编译目标文件。
 
 : `dynlib`
 
-  A shared library (e.g., for the Lean option `--load-dynlib`){TODO}[Document Lean command line options, and cross-reference from here].
+  共享库（例如，用于 Lean 选项 `--load-dynlib`）{TODO}[记录 Lean 命令行选项的文档，并从此处提供交叉引用]。
 
 : `ltar`
 
-  A compressed archive (produced via `leantar`) of the module's build artifacts. {TODO}[Document `leantar` in the manual as well]
+  包含模块构建工件的压缩包（通过 `leantar` 生成）。{TODO}[请同时在手册中记录 `leantar` 的文档。]
 
 : `linkInfoExport`
 
-  A structured representation of the linker arguments, static objects, and dynamic libraries needed to link a module and its dependencies. Objects have Lean symbols exported.
+  要链接一个模块及其依赖所需的链接器参数、静态对象和动态库的结构化表示。这些对象会导出 Lean 符号。
 
 : `linkInfoNoExport`
 
-  A structured representation of the linker arguments, static objects, and dynamic libraries needed to link a module and its dependencies. Objects do not Lean symbols exported.
+  要链接一个模块及其依赖所需的链接器参数、静态对象和动态库的结构化表示。这些对象不导出 Lean 符号。
 
 :::
 
 
-## Scripts
+## 脚本
 %%%
 tag := "lake-scripts"
 %%%
 
-Lake {tech}[package configuration] files may include {deftech}_Lake scripts_, which are embedded programs that can be executed from the command line.
-Scripts are intended to be used for project-specific tasks that are not already well-served by Lake's other features.
-While ordinary executable programs are run in the {name}`IO` {tech}[monad], scripts are run in {name Lake.ScriptM}`ScriptM`, which extends {name}`IO` with information about the workspace.
-Because they are Lean definitions, Lake scripts can only be defined in the Lean configuration format.
+Lake {tech (key := "package configuration")}[包配置] 文件可包含 {deftech (key := "Lake scripts")}_Lake 脚本_，这些脚本是可从命令行执行的内嵌程序。
+脚本旨在用于特定于项目、且 Lake 的其他特性尚未能很好地处理的任务。
+普通的执行程序在 {name}`IO` {tech (key := "monad")}[单子] 中运行，而脚本在 {name Lake.ScriptM}`ScriptM` 中运行，后者在 {name}`IO` 的基础上扩展了有关工作区的信息。
+因为它们是 Lean 定义，Lake 脚本只能在 Lean 配置格式中定义。
 
 :::::TODO
 
-Restore the following once we can import enough of Lake to elaborate it
+一旦能够导入足够多的 Lake 以进行推导，恢复以下内容：
 
 ````
 ```lean -show
@@ -644,10 +644,10 @@ section
 open Lake DSL
 ```
 
-:::example "Listing Dependencies"
+:::example "列出依赖" (file := "Listing Dependencies")
 
-This Lake script lists all the transitive dependencies of the root package, along with their Git URLs, in alphabetical order.
-Similar scripts could be used to check declared licenses, discover which dependencies have test drivers configured, or compute metrics about the transitive dependency set over time.
+此 Lake 脚本按字母顺序列出根包的所有传递依赖及其 Git URL。
+类似的脚本可以用于检查已声明的许可证、发现哪些依赖已配置测试驱动程序，或者随时间计算传递依赖集的各项指标。
 
 ```lean
 script "list-deps" := do
@@ -670,31 +670,31 @@ end
 
 :::::
 
-## Test and Lint Drivers
+## 测试和代码检查驱动程序
 %%%
 tag := "test-lint-drivers"
 %%%
 
-A {deftech}_test driver_ runs the tests for a package.
-It can be an executable target, a {tech}[Lake script], or a library.
-Lake itself isn't a test framework: the {lake}`test` command just locates the configured target, builds it, and (for executables and scripts) runs it.
-Library drivers are exercised purely by elaboration, so they aren't run as a separate step.
-Assertions, test discovery, and reporting are up to the target itself, whether that's a third-party testing library or hand-written checks.
+{deftech (key := "test driver")}_测试驱动程序_ 负责运行一个包的测试。
+它可以是可执行目标、{tech (key := "Lake script")}[Lake 脚本] 或库。
+Lake 本身并不是测试框架：{lake}`test` 命令只是定位已配置的目标，构建它，并且（针对可执行文件和脚本）运行它。
+库的驱动程序纯粹通过推导来执行，因此它们不会作为单独的步骤运行。
+断言、测试发现以及报告都由目标本身决定，这既可以是第三方测试库，也可以是手写的检查。
 
-For executables and scripts, Lake treats a nonzero exit code as a test failure.
-For libraries, any elaboration error counts as a test failure, including failures of {keyword}`#guard`-style commands.
+对于可执行文件和脚本，Lake 将非零退出代码视为测试失败。
+对于库，任何推导错误均算作测试失败，包括 {keyword}`#guard` 风格命令的失败。
 
-A {deftech}_lint driver_ is similar, but it's run by {lake}`lint` and checks the package for stylistic issues and other problems that aren't _errors_ but indicate likely problems.
-Lint drivers can only be executables or scripts, not libraries.
+{deftech (key := "lint driver")}_代码检查驱动程序_ 也是类似的，只是它由 {lake}`lint` 运行，负责检查包在风格及其他方面是否存在不是_错误_但预示存在潜在问题的状况。
+代码检查驱动程序只能是可执行文件或脚本，而不能是库。
 
-### Configuring a Test Driver
+### 配置测试驱动程序
 %%%
 tag := "lake-test-driver-config"
 %%%
 
-In a `lakefile.toml`, set {tomlField Lake.PackageConfig}`testDriver` to the name of an executable target, library target, or script defined in the same configuration:
+在 `lakefile.toml` 中，将 {tomlField Lake.PackageConfig}`testDriver` 设置为相同配置中定义的可执行文件目标、库目标或脚本的名称：
 
-:::::example "Test Driver (`lakefile.toml`)"
+:::::example "测试驱动（`lakefile.toml`）" (file := "Test Driver (lakefile.toml)")
 
 ::::lakeToml Lake.PackageConfig _root_
 ```toml
@@ -853,10 +853,10 @@ root = "Tests"
 ::::
 :::::
 
-In a `lakefile.lean`, either set the {name Lake.Package.testDriver}`testDriver` field on the {keyword}`package` declaration (as above), or tag a script, executable, or library declaration with the {attr}`test_driver` attribute.
-The attribute form is often convenient because it places the marker next to the target.
+在 `lakefile.lean` 中，可以在 {keyword}`package` 声明中设置 {name Lake.Package.testDriver}`testDriver` 字段（如上所述），也可以使用 {attr}`test_driver` 属性对脚本、可执行文件或库声明进行标记。
+属性标记的形式往往更方便，因为它将标记放在了目标旁边。
 
-:::::example "Test Driver (`lakefile.lean`)"
+:::::example "测试驱动（`lakefile.lean`）" (file := "Test Driver (lakefile.lean)")
 
 ::::lakeLean
 ```lean
@@ -1017,52 +1017,52 @@ lean_exe «my-package-tests» where
 ::::
 :::::
 
-Only one declaration per package can be tagged with {attr}`test_driver`.
-It is an error to use both the {attr}`test_driver` attribute and a non-empty {name Lake.Package.testDriver}`testDriver` field in the same Lake configuration file.
+每个包中只有一个声明可以被标记为 {attr}`test_driver`。
+如果在同一 Lake 配置文件中同时使用 {attr}`test_driver` 属性和非空的 {name Lake.Package.testDriver}`testDriver` 字段，则会引发错误。
 
-A test driver may also be a target in a package dependency that is transitively {tech (key:="require")}[required].
-To use a target from another package, use `<pkg>/<name>` as the value of `testDriver`, where `<pkg>` is the name of the package in which the target is found..
+测试驱动程序也可以是传递地 {tech (key:="require")}[请求] 的包依赖项中的目标。
+要使用其他包中的目标，请使用 `<pkg>/<name>` 作为 `testDriver` 的值，其中 `<pkg>` 是该目标所在的包的名称。
 
-### Running Tests
+### 运行测试
 %%%
 tag := "lake-test-running"
 %%%
 
-The {lake}`test` command runs the configured driver for the {tech}[root package] only.
-Test drivers for dependencies are not run.
+{lake}`test` 命令仅运行 {tech (key := "root package")}[根包] 已配置的驱动程序。
+不会运行依赖项的测试驱动程序。
 
 :::paragraph
-If the test driver is an executable or a script, Lake passes the arguments from {tomlField Lake.PackageConfig}`testDriverArgs` first, then anything after `--` on the command line.
-For example,
+如果测试驱动程序是可执行文件或脚本，Lake 会先传递 {tomlField Lake.PackageConfig}`testDriverArgs` 中的参数，然后传递命令行上 `--` 之后的所有内容。
+例如，
 
 ```
 lake test -- --filter Foo --verbose
 ```
 
-passes `--filter Foo --verbose` to the driver after whatever {tomlField Lake.PackageConfig}`testDriverArgs` is already configured.
-Lake builds executable drivers before running them.
+将在任何已配置好的 {tomlField Lake.PackageConfig}`testDriverArgs` 后，把 `--filter Foo --verbose` 传递给驱动程序。
+Lake 在运行可执行文件驱动程序前会先对其进行构建。
 :::
 
-If the test driver is a library, arguments are not accepted.
-Lake reports an error if {tomlField Lake.PackageConfig}`testDriverArgs` is non-empty or if any arguments follow `--`.
-To run the tests, the library is just {tech (key:="Lean elaborator")}[elaborated].
+如果测试驱动程序是库，则不接受参数。
+如果 {tomlField Lake.PackageConfig}`testDriverArgs` 不为空，或在 `--` 之后有任何参数，Lake 将报告错误。
+要运行测试，只需使用 {tech (key:="Lean elaborator")}[Lean 推导器] 对该库进行推导即可。
 
-{lake}`check-test` terminates with exit code 0 (that is, successfully) if a test driver is configured for the root package.
-It doesn't check that the named target actually exists.
+如果为根包配置了测试驱动程序，{lake}`check-test` 将以退出代码 0（即成功）终止。
+它不检查所命名的目标是否实际存在。
 
-### Lint Drivers
+### 代码检查驱动程序
 %%%
 tag := "lake-lint-drivers"
 %%%
 
-Lint drivers are configured and run similarly to {ref "lake-test-driver-config"}[test drivers].
-The Lake configuration file specifies a target that serves as the lint driver, and {lake}`lint` runs it.
-This target must be an executable or a script; unlike test drivers, lint drivers may not be libraries.
+代码检查驱动程序的配置和运行方式类似于 {ref "lake-test-driver-config"}[测试驱动程序]。
+Lake 配置文件指定一个目标作为代码检查驱动程序，然后由 {lake}`lint` 运行它。
+此目标必须是可执行文件或脚本；与测试驱动程序不同，代码检查驱动程序不能是库。
 
-In a TOML-format Lake configuration file, the package-level field {tomlField Lake.PackageConfig}`lintDriver` specifies the name of the lint driver target.
+在 TOML 格式的 Lake 配置文件中，包级别的 {tomlField Lake.PackageConfig}`lintDriver` 字段指定了代码检查驱动程序目标的名称。
 
-:::::example "Lint Driver (`lakefile.toml`)"
-This minimal `lakefile.toml` configures a lint driver:
+:::::example "代码检查驱动（`lakefile.toml`）" (file := "Lint Driver (lakefile.toml)")
+这个最小化的 `lakefile.toml` 配置了一个代码检查驱动程序：
 
 ::::lakeToml Lake.PackageConfig _root_
 ```toml
@@ -1222,10 +1222,10 @@ root = "Lint"
 :::::
 
 
-In a `lakefile.lean`, either set the {name Lake.Package.lintDriver}`lintDriver` field on the {keyword}`package` declaration, or tag a script or executable declaration with the {attr}`lint_driver` attribute.
-The attribute form is often convenient because it places the marker next to the target.
+在 `lakefile.lean` 中，可以在 {keyword}`package` 声明中设置 {name Lake.Package.lintDriver}`lintDriver` 字段，也可以使用 {attr}`lint_driver` 属性标记脚本或可执行文件声明。
+属性的形式往往更方便，因为它将标记放在了目标旁边。
 
-:::::example "Lint Driver (`lakefile.lean`)"
+:::::example "代码检查驱动（`lakefile.lean`）" (file := "Lint Driver (lakefile.lean)")
 
 ::::lakeLean
 ```lean
@@ -1386,8 +1386,8 @@ lean_exe «my-package-lint» where
 ::::
 :::::
 
-Only one declaration per package can be tagged with {attr}`lint_driver`.
-It is an error to use both the {attr}`lint_driver` attribute and a non-empty {name Lake.Package.lintDriver}`lintDriver` field in the same Lake configuration file.
+每个包中只有一个声明可以被标记为 {attr}`lint_driver`。
+如果在同一 Lake 配置文件中同时使用 {attr}`lint_driver` 属性和非空的 {name Lake.Package.lintDriver}`lintDriver` 字段，则会引发错误。
 
 :::lakeSession -show
 ```lean +lakefile
@@ -1406,90 +1406,90 @@ error: p: only one script or executable can be tagged @[lint_driver]
 ```
 :::
 
-A lint driver in a dependency package can be referenced with the same `<pkg>/<name>` syntax used for test drivers.
+依赖包中的代码检查驱动程序可以使用与测试驱动程序相同的 `<pkg>/<name>` 语法进行引用。
 
-{lake}`lint` runs the configured driver, passing {tomlField Lake.PackageConfig}`lintDriverArgs` first, then anything after `--` on the command line:
+{lake}`lint` 运行已配置的驱动程序，首先传递 {tomlField Lake.PackageConfig}`lintDriverArgs`，然后传递命令行上 `--` 之后的任何内容：
 
 ```
 lake lint -- --warnings-as-errors
 ```
 
-Lake also has a separate {deftech}_builtin linter_ that operates on Lean modules directly, independent of any configured driver.
-Builtin linting is enabled by the `--builtin-lint` and related flags (see {lake}`lint`), or by setting {tomlField Lake.PackageConfig}`builtinLint` to `true` in the package configuration.
-When builtin linting is active, positional `MODULE` arguments before `--` select which modules to lint, and they are _not_ passed to the configured driver.
-So `lake lint Mathlib` triggers builtin linting on `Mathlib`, whereas `lake lint -- Mathlib` passes `Mathlib` to the driver.
-The two mechanisms are independent and can run together: when both apply, Lake runs the builtin linter first and then the driver.
+Lake 还有单独的 {deftech (key := "builtin linter")}_内置检查器_，它直接在 Lean 模块上运行，独立于任何已配置的驱动程序。
+内置代码检查可以通过 `--builtin-lint` 及相关标志（见 {lake}`lint`）启用，或通过在包配置中将 {tomlField Lake.PackageConfig}`builtinLint` 设置为 `true` 来启用。
+当内置代码检查启用时，`--` 之前的位置参数 `MODULE` 用于选择要检查的模块，而且它们*不会*被传递给已配置的驱动程序。
+因此 `lake lint Mathlib` 会触发对 `Mathlib` 的内置代码检查，而 `lake lint -- Mathlib` 则会将 `Mathlib` 传递给驱动程序。
+这两种机制相互独立且可同时运行：当它们同时适用时，Lake 将先运行内置检查器，然后再运行驱动程序。
 
-{lake}`check-lint` exits with code 0 (that is, successfully) if a lint driver is configured for the root package or if {tomlField Lake.PackageConfig}`builtinLint` is set to `true` in its configuration.
+如果为根包配置了代码检查驱动程序，或者其配置中的 {tomlField Lake.PackageConfig}`builtinLint` 被设置为 `true`，{lake}`check-lint` 将以退出代码 0（即成功）退出。
 
 
-## GitHub Release Builds
+## GitHub 发布版本构建
 %%%
 tag := "lake-github"
 %%%
 
-Lake supports uploading and downloading build artifacts (i.e., the archived build directory) to/from the GitHub releases of packages.
-This enables end users to fetch pre-built artifacts from the cloud without needed to rebuild the package from source themselves.
-The {envVar}`LAKE_NO_CACHE` environment variable can be used to disable this feature.
+Lake 支持将构建工件（即归档后的构建目录）上传到包的 GitHub 发布版本中，或从其中下载。
+这使得最终用户能够从云端获取预构建的工件，而无需自己从源码重建整个包。
+可以使用 {envVar}`LAKE_NO_CACHE` 环境变量来禁用此功能。
 
-### Downloading
+### 下载
 
-To download artifacts, one should configure the package options `releaseRepo` and `buildArchive` to point to the GitHub repository hosting the release and the correct artifact name within it (if the defaults are not sufficient).
-Then, set `preferReleaseBuild := true` to tell Lake to fetch and unpack it as an extra package dependency.
+要下载工件，应配置包选项 `releaseRepo` 和 `buildArchive`，使其指向托管发布版本的 GitHub 仓库以及其中正确的工件名称（如果默认设置不充分）。
+然后，设置 `preferReleaseBuild := true`，指示 Lake 将其作为额外的包依赖项获取并解包。
 
-Lake will only fetch release builds as part of its standard build process if the package wanting it is a dependency (as the root package is expected to modified and thus not often compatible with this scheme).
-However, should one wish to fetch a release for a root package (e.g., after cloning the release's source but before editing), one can manually do so via `lake build :release`.
+作为标准构建过程的一部分，Lake 仅当需要发布版本构建的包属于依赖时才会获取它（因为根包通常会被修改，所以它往往与此方案不兼容）。
+但是，如果希望为根包获取发布版本构建（例如，在克隆发布版本的源代码之后、编辑之前），可以通过 `lake build :release` 手动执行。
 
-Lake internally uses `curl` to download the release and `tar` to unpack it, so the end user must have both tools installed in order to use this feature.
-If Lake fails to fetch a release for any reason, it will move on to building from the source.
-This mechanism is not technically limited to GitHub: any Git host that uses the same URL scheme works as well.
+Lake 在内部使用 `curl` 下载发布版本，并使用 `tar` 将其解包，因此最终用户必须安装这两种工具才能使用此功能。
+如果 Lake 因任何原因未能获取发布版本，它将继续从源代码构建。
+该机制在技术上不仅限于 GitHub：任何使用相同 URL 方案的 Git 托管平台同样适用。
 
-### Uploading
+### 上传
 
-To upload a built package as an artifact to a GitHub release, Lake provides the {lake}`upload` command as a convenient shorthand.
-This command uses `tar` to pack the package's build directory into an archive and uses `gh release upload` to attach it to a pre-existing GitHub release for the specified tag.
-Thus, in order to use it, the package uploader (but not the downloader) needs to have `gh`, the GitHub CLI, installed and in `PATH`.
+要将构建的包作为工件上传到 GitHub 发布版本，Lake 提供了 {lake}`upload` 命令作为便捷的简写。
+此命令使用 `tar` 将包的构建目录打包为归档，并使用 `gh release upload` 将其附加到指定标签下预先存在的 GitHub 发布版本中。
+因此，为了使用该命令，包的上传者（但不是下载者）需要安装 GitHub 命令行界面 `gh` 并将其包含在 `PATH` 中。
 
-## Artifact Caches
+## 工件缓存
 %%%
 tag := "lake-cache"
 %%%
 
-*This is an experimental feature that is still undergoing development.*
+*这是一项仍在开发中的实验性功能。*
 
-Lake supports a {deftech (key := "local cache")}_local artifact cache_ that stores individual build products, tracking the complete set of inputs that gave rise to them.
-Each {tech}[toolchain] has its own cache because intermediate build products are not compatible between toolchain versions.
-However, a toolchain's cache is shared between all local {tech}[workspaces] that use it, so common dependencies don't need to be rebuilt.
-If two separate workspaces with the same toolchain depend on the same package, then they can share each others' build products.
+Lake 支持 {deftech (key := "local cache")}_本地工件缓存_，该缓存会存储单个构建产物，并追踪生成它们的所有输入集。
+每个 {tech (key := "toolchain")}[工具链] 都有其自己的缓存，因为工具链版本之间的中间构建产物是不兼容的。
+不过，一个工具链的缓存在使用它的所有本地 {tech (key := "workspaces")}[工作区] 之间是共享的，因此常见的依赖不需要重新构建。
+如果两个具有相同工具链的独立工作区依赖于相同的包，则它们可以共享彼此的构建产物。
 
-Because it is an experimental feature, the local cache is disabled by default.
-It is only enabled when the {envVar}`LAKE_ARTIFACT_CACHE` environment variable is set to `true` or when the {TODO}[ref] `enableArtifactCache` field is set to `true` in the {ref "lake-config"}[configuration file].
+因为这是一项实验性功能，所以本地缓存默认处于禁用状态。
+只有当 {envVar}`LAKE_ARTIFACT_CACHE` 环境变量被设置为 `true`，或者当 {TODO}[ref] `enableArtifactCache` 字段在 {ref "lake-config"}[配置文件] 中被设置为 `true` 时才会被启用。
 
 
-### Remote Artifact Caches
+### 远程工件缓存
 %%%
 tag := "lake-cache-remote"
 %%%
 
-Build products can be retrieved from remote cache servers and placed into the local cache.
-This makes it possible to completely avoid local builds.
-The {lake}`cache get` command is used to download artifacts into the local cache.
+构建产物可以从远程缓存服务器检索，并放入本地缓存中。
+这使得完全避免本地构建成为可能。
+{lake}`cache get` 命令用于将工件下载到本地缓存中。
 
-Compared to {ref "lake-github"}[GitHub release builds], the remote artifact cache is much more fine-grained.
-It tracks build products at the level of individual source files, {tech}[`.olean` files], and object code, rather than at the level of entire packages.
+与 {ref "lake-github"}[GitHub 发布版本构建] 相比，远程工件缓存的粒度要细得多。
+它追踪源代码文件级别、{tech (key := ".olean files")}[`.olean` 文件] 以及目标代码级别的构建产物，而不是整个包级别的。
 
-### Mappings
+### 映射
 
-When passed the `-o` option, {lake}`build` tracks the inputs used to generate each build product.
-These are stored to a {deftech}_mappings file_ in JSON lines format, where each line of the file must be a valid JSON object.
-A mappings file tracks a single build, and includes all intermediate and final build products for the workspace's {tech}[root package], but not for its dependencies.
-This includes build products that were already up to date and not regenerated.
-The {lake}`cache put` command uploads the build products in the mappings file to the remote from the local cache to the remote cache.
+当传递 `-o` 选项时，{lake}`build` 会追踪用于生成每个构建产物的输入。
+它们被存储为 JSON 行格式的 {deftech (key := "mappings file")}_映射文件_，文件中每一行都必须是一个有效的 JSON 对象。
+一个映射文件追踪单次构建，包括工作区 {tech (key := "root package")}[根包] 的所有中间和最终构建产物，但不包含其依赖。
+这包括那些已经处于最新状态且不需要重新生成的构建产物。
+{lake}`cache put` 命令从本地缓存把映射文件中的构建产物上传到远程缓存。
 
-### Configuration
+### 配置
 
 :::paragraph
-Remote artifact caches are configured using the following environment variables:
+使用以下环境变量配置远程工件缓存：
  * {envVar}`LAKE_CACHE_KEY`
  * {envVar}`LAKE_CACHE_ARTIFACT_ENDPOINT`
  * {envVar}`LAKE_CACHE_REVISION_ENDPOINT`
@@ -1499,20 +1499,20 @@ Remote artifact caches are configured using the following environment variables:
 
 {include 0 Manual.BuildTools.Lake.Config}
 
-# Script API Reference
+# 脚本 API 参考
 %%%
 tag := "lake-api"
 %%%
 
-In addition to ordinary {lean}`IO` effects, Lake scripts have access to the Lake environment (which provides information about the current toolchain, such as the location of the Lean compiler) and the current workspace.
-This access is provided in {name Lake.ScriptM}`ScriptM`.
+除了普通的 {lean}`IO` 效应，Lake 脚本还能访问 Lake 环境（它提供了有关当前工具链的信息，例如 Lean 编译器的位置）以及当前的工作区。
+这一访问权限是在 {name Lake.ScriptM}`ScriptM` 中提供的。
 
 {docstring Lake.ScriptM}
 
-## Accessing the Environment
+## 访问环境
 
-Monads that provide access to information about the current Lake environment (such as the locations of Lean, Lake, and other tools) have {name Lake.MonadLakeEnv}`MonadLakeEnv` instances.
-This is true for all of the monads in the Lake API, including {name Lake.ScriptM}`ScriptM`.
+提供对当前 Lake 环境信息（例如 Lean、Lake 以及其它工具的位置）访问权限的单子具备 {name Lake.MonadLakeEnv}`MonadLakeEnv` 实例。
+Lake API 中的所有单子皆是如此，包括 {name Lake.ScriptM}`ScriptM`。
 
 {docstring Lake.MonadLakeEnv}
 
@@ -1526,7 +1526,7 @@ This is true for all of the monads in the Lake API, including {name Lake.ScriptM
 
 {docstring Lake.getElanToolchain}
 
-### Search Path Helpers
+### 搜索路径辅助函数
 
 {docstring Lake.getEnvLeanPath}
 
@@ -1534,7 +1534,7 @@ This is true for all of the monads in the Lake API, including {name Lake.ScriptM
 
 {docstring Lake.getEnvSharedLibPath}
 
-### Elan Install Helpers
+### Elan 安装辅助函数
 
 {docstring Lake.getElanInstall?}
 
@@ -1542,7 +1542,7 @@ This is true for all of the monads in the Lake API, including {name Lake.ScriptM
 
 {docstring Lake.getElan?}
 
-### Lean Install Helpers
+### Lean 安装辅助函数
 
 {docstring Lake.getLeanInstall}
 
@@ -1568,7 +1568,7 @@ This is true for all of the monads in the Lake API, including {name Lake.ScriptM
 
 {docstring Lake.getLeanCc?}
 
-### Lake Install Helpers
+### Lake 安装辅助函数
 
 {docstring Lake.getLakeInstall}
 
@@ -1580,10 +1580,10 @@ This is true for all of the monads in the Lake API, including {name Lake.ScriptM
 
 {docstring Lake.getLake}
 
-## Accessing the Workspace
+## 访问工作区
 
-Monads that provide access to information about the current Lake workspace have {name Lake.MonadWorkspace}`MonadWorkspace` instances.
-In particular, there are instances for {name Lake.ScriptM}`ScriptM` and {name Lake.LakeM}`LakeM`.
+提供对当前 Lake 工作区信息访问权限的单子具备 {name Lake.MonadWorkspace}`MonadWorkspace` 实例。
+特别是，有针对 {name Lake.ScriptM}`ScriptM` 和 {name Lake.LakeM}`LakeM` 的实例。
 
 ```lean -show
 section

--- a/Manual/BuildTools/Lake.lean
+++ b/Manual/BuildTools/Lake.lean
@@ -139,7 +139,7 @@ open Illuminate in
 :::paragraph
 {deftech (key := "target")}_目标_ 表示用户可以请求的输出。
 持久的构建输出，例如目标代码、可执行二进制文件或 {tech (key := ".olean file")}[`.olean` 文件]，被称为 {deftech (key := "artifact")}_工件_。
-在生成工件的过程中，Lake 可能需要生成进一步的工件；例如，将 Lean 程序编译为可执行文件要求它及其依赖被编译为目标文件，而这些文件本身是从 C 源文件生成的，C 源文件则是通过对 Lean 源文件进行推导并生成 {tech (key := ".olean files")}[`.olean` 文件] 得出的。
+在生成工件的过程中，Lake 可能需要生成进一步的工件；例如，将 Lean 程序编译为可执行文件要求它及其依赖被编译为目标文件，而这些文件本身是从 C 源文件生成的，C 源文件则是通过对 Lean 源文件进行精译并生成 {tech (key := ".olean files")}[`.olean` 文件] 得出的。
 该链条中的每个环节都是一个目标，Lake 会安排它们依次构建。
 处于链条起点的是 {deftech (key := "initial targets")}_初始目标_：
  * {tech (key := "Packages")}_包_ 是作为一个单元分发的 Lean 代码单元。
@@ -161,7 +161,7 @@ open Illuminate in
  1. _追踪消息_包含通常特定于运行构建的机器的内部构建详细信息，包括传递给命令外壳的 Lean 及其他工具的具体调用。
  2. _信息性消息_包含通常不表示代码有问题的常规信息输出，例如 {keywordOf Lean.Parser.Command.eval}`#eval` 命令的结果。
  3. _警告_指出潜在问题，例如未使用的变量绑定。
- 4. _错误_解释为什么解析和推导无法完成。
+ 4. _错误_解释为什么解析和精译无法完成。
 
 默认情况下，追踪消息被隐藏，其他的被显示。
 阈值可以通过 {lakeOpt}`--log-level` 选项、{lakeOpt}`--verbose` 标志或 {lakeOpt}`--quiet` 标志进行调整。
@@ -254,9 +254,9 @@ tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Concept
 
 : {deftech (key := "configure package")}[配置包]
 
-  如果 {tech (key := "package configuration")}[包配置] 文件比缓存的配置文件 `lakefile.olean` 更新，那么包配置就会被重新推导。
+  如果 {tech (key := "package configuration")}[包配置] 文件比缓存的配置文件 `lakefile.olean` 更新，那么包配置就会被重新精译。
   当缓存文件缺失或者提供了 {lakeOpt}`--reconfigure` 或 {lakeOpt}`-R` 标志时，也会发生这种情况。
-  使用 {lakeOpt}`-K` 对选项的更改不会触发配置文件的重新推导；在这些情况下，必须使用 {lakeOpt}`-R`。
+  使用 {lakeOpt}`-K` 对选项的更改不会触发配置文件的重新精译；在这些情况下，必须使用 {lakeOpt}`-R`。
 
 : 计算依赖
 
@@ -294,7 +294,7 @@ Lake 使用两种不同的哈希算法。
  * {deftech (key := "source directory")}_源码目录_ 包含可供导入的 Lean 源代码。
  * {deftech (key := "library directories")}_库目录_ 包含 {tech (key := ".olean files")}[`.olean` 文件] 以及可用于链接的共享库和静态库；它通常由 {tech (key := "root package")}[根包] 的库目录（在 `.lake/build/lib` 下）、工作区中其他包的库目录、当前 Lean 工具链的库目录以及系统库目录组成。
  * {deftech (key := "Lake home")}_Lake 主目录_ 是安装 Lake 的目录，包含二进制文件、源代码和库。
-   Lake 目录中的库在推导 Lake 配置文件时不可或缺，这样配置文件就能访问 Lean 的全部功能。
+   Lake 目录中的库在精译 Lake 配置文件时不可或缺，这样配置文件就能访问 Lean 的全部功能。
 :::
 
 ## 分面
@@ -641,7 +641,7 @@ Lake {tech (key := "package configuration")}[包配置] 文件可包含 {deftech
 
 :::::TODO
 
-一旦能够导入足够多的 Lake 以进行推导，恢复以下内容：
+一旦能够导入足够多的 Lake 以进行精译，恢复以下内容：
 
 ````
 ```lean -show
@@ -683,11 +683,11 @@ tag := "test-lint-drivers"
 {deftech (key := "test driver")}_测试驱动程序_ 负责运行一个包的测试。
 它可以是可执行目标、{tech (key := "Lake script")}[Lake 脚本] 或库。
 Lake 本身并不是测试框架：{lake}`test` 命令只是定位已配置的目标，构建它，并且（针对可执行文件和脚本）运行它。
-库的驱动程序纯粹通过推导来执行，因此它们不会作为单独的步骤运行。
+库的驱动程序纯粹通过精译来执行，因此它们不会作为单独的步骤运行。
 断言、测试发现以及报告都由目标本身决定，这既可以是第三方测试库，也可以是手写的检查。
 
 对于可执行文件和脚本，Lake 将非零退出代码视为测试失败。
-对于库，任何推导错误均算作测试失败，包括 {keyword}`#guard` 风格命令的失败。
+对于库，任何精译错误均算作测试失败，包括 {keyword}`#guard` 风格命令的失败。
 
 {deftech (key := "lint driver")}_代码检查驱动程序_ 也是类似的，只是它由 {lake}`lint` 运行，负责检查包在风格及其他方面是否存在不是_错误_但预示存在潜在问题的状况。
 代码检查驱动程序只能是可执行文件或脚本，而不能是库。
@@ -1050,7 +1050,7 @@ Lake 在运行可执行文件驱动程序前会先对其进行构建。
 
 如果测试驱动程序是库，则不接受参数。
 如果 {tomlField Lake.PackageConfig}`testDriverArgs` 不为空，或在 `--` 之后有任何参数，Lake 将报告错误。
-要运行测试，只需使用 {tech (key:="Lean elaborator")}[Lean 推导器] 对该库进行推导即可。
+要运行测试，只需使用 {tech (key:="Lean elaborator")}[Lean 精译器] 对该库进行精译即可。
 
 如果为根包配置了测试驱动程序，{lake}`check-test` 将以退出代码 0（即成功）终止。
 它不检查所命名的目标是否实际存在。

--- a/Manual/BuildTools/Lake.lean
+++ b/Manual/BuildTools/Lake.lean
@@ -13,6 +13,7 @@ import Lake.Build.Module
 
 
 import Manual.Meta
+import Manual.ZhDocString.BuildTools.Lake
 import Manual.BuildTools.Lake.CLI
 import Manual.BuildTools.Lake.Config
 
@@ -1523,7 +1524,7 @@ tag := "lake-api"
 除了普通的 {lean}`IO` 效应，Lake 脚本还能访问 Lake 环境（它提供了有关当前工具链的信息，例如 Lean 编译器的位置）以及当前的工作区。
 这一访问权限是在 {name Lake.ScriptM}`ScriptM` 中提供的。
 
-{docstring Lake.ScriptM}
+{zhdocstring Lake.ScriptM ZhDoc.BuildTools.Lake.ScriptM}
 
 ## 访问环境
 %%%
@@ -1533,83 +1534,83 @@ tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Script-
 提供对当前 Lake 环境信息（例如 Lean、Lake 以及其它工具的位置）访问权限的单子具备 {name Lake.MonadLakeEnv}`MonadLakeEnv` 实例。
 Lake API 中的所有单子皆是如此，包括 {name Lake.ScriptM}`ScriptM`。
 
-{docstring Lake.MonadLakeEnv}
+{zhdocstring Lake.MonadLakeEnv ZhDoc.BuildTools.Lake.MonadLakeEnv}
 
-{docstring Lake.getLakeEnv}
+{zhdocstring Lake.getLakeEnv ZhDoc.BuildTools.Lake.getLakeEnv}
 
-{docstring Lake.getNoCache}
+{zhdocstring Lake.getNoCache ZhDoc.BuildTools.Lake.getNoCache}
 
-{docstring Lake.getTryCache}
+{zhdocstring Lake.getTryCache ZhDoc.BuildTools.Lake.getTryCache}
 
-{docstring Lake.getPkgUrlMap}
+{zhdocstring Lake.getPkgUrlMap ZhDoc.BuildTools.Lake.getPkgUrlMap}
 
-{docstring Lake.getElanToolchain}
+{zhdocstring Lake.getElanToolchain ZhDoc.BuildTools.Lake.getElanToolchain}
 
 ### 搜索路径辅助函数
 %%%
 tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Script-API-Reference--Accessing-the-Environment--Search-Path-Helpers"
 %%%
 
-{docstring Lake.getEnvLeanPath}
+{zhdocstring Lake.getEnvLeanPath ZhDoc.BuildTools.Lake.getEnvLeanPath}
 
-{docstring Lake.getEnvLeanSrcPath}
+{zhdocstring Lake.getEnvLeanSrcPath ZhDoc.BuildTools.Lake.getEnvLeanSrcPath}
 
-{docstring Lake.getEnvSharedLibPath}
+{zhdocstring Lake.getEnvSharedLibPath ZhDoc.BuildTools.Lake.getEnvSharedLibPath}
 
 ### Elan 安装辅助函数
 %%%
 tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Script-API-Reference--Accessing-the-Environment--Elan-Install-Helpers"
 %%%
 
-{docstring Lake.getElanInstall?}
+{zhdocstring Lake.getElanInstall? ZhDoc.BuildTools.Lake.getElanInstall?}
 
-{docstring Lake.getElanHome?}
+{zhdocstring Lake.getElanHome? ZhDoc.BuildTools.Lake.getElanHome?}
 
-{docstring Lake.getElan?}
+{zhdocstring Lake.getElan? ZhDoc.BuildTools.Lake.getElan?}
 
 ### Lean 安装辅助函数
 %%%
 tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Script-API-Reference--Accessing-the-Environment--Lean-Install-Helpers"
 %%%
 
-{docstring Lake.getLeanInstall}
+{zhdocstring Lake.getLeanInstall ZhDoc.BuildTools.Lake.getLeanInstall}
 
-{docstring Lake.getLeanSysroot}
+{zhdocstring Lake.getLeanSysroot ZhDoc.BuildTools.Lake.getLeanSysroot}
 
-{docstring Lake.getLeanSrcDir}
+{zhdocstring Lake.getLeanSrcDir ZhDoc.BuildTools.Lake.getLeanSrcDir}
 
-{docstring Lake.getLeanLibDir}
+{zhdocstring Lake.getLeanLibDir ZhDoc.BuildTools.Lake.getLeanLibDir}
 
-{docstring Lake.getLeanIncludeDir}
+{zhdocstring Lake.getLeanIncludeDir ZhDoc.BuildTools.Lake.getLeanIncludeDir}
 
-{docstring Lake.getLeanSystemLibDir}
+{zhdocstring Lake.getLeanSystemLibDir ZhDoc.BuildTools.Lake.getLeanSystemLibDir}
 
-{docstring Lake.getLean}
+{zhdocstring Lake.getLean ZhDoc.BuildTools.Lake.getLean}
 
-{docstring Lake.getLeanc}
+{zhdocstring Lake.getLeanc ZhDoc.BuildTools.Lake.getLeanc}
 
-{docstring Lake.getLeanSharedLib}
+{zhdocstring Lake.getLeanSharedLib ZhDoc.BuildTools.Lake.getLeanSharedLib}
 
-{docstring Lake.getLeanAr}
+{zhdocstring Lake.getLeanAr ZhDoc.BuildTools.Lake.getLeanAr}
 
-{docstring Lake.getLeanCc}
+{zhdocstring Lake.getLeanCc ZhDoc.BuildTools.Lake.getLeanCc}
 
-{docstring Lake.getLeanCc?}
+{zhdocstring Lake.getLeanCc? ZhDoc.BuildTools.Lake.getLeanCc?}
 
 ### Lake 安装辅助函数
 %%%
 tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Script-API-Reference--Accessing-the-Environment--Lake-Install-Helpers"
 %%%
 
-{docstring Lake.getLakeInstall}
+{zhdocstring Lake.getLakeInstall ZhDoc.BuildTools.Lake.getLakeInstall}
 
-{docstring Lake.getLakeHome}
+{zhdocstring Lake.getLakeHome ZhDoc.BuildTools.Lake.getLakeHome}
 
-{docstring Lake.getLakeSrcDir}
+{zhdocstring Lake.getLakeSrcDir ZhDoc.BuildTools.Lake.getLakeSrcDir}
 
-{docstring Lake.getLakeLibDir}
+{zhdocstring Lake.getLakeLibDir ZhDoc.BuildTools.Lake.getLakeLibDir}
 
-{docstring Lake.getLake}
+{zhdocstring Lake.getLake ZhDoc.BuildTools.Lake.getLake}
 
 ## 访问工作区
 %%%
@@ -1627,32 +1628,32 @@ open Lake
 end
 ```
 
-{docstring Lake.MonadWorkspace}
+{zhdocstring Lake.MonadWorkspace ZhDoc.BuildTools.Lake.MonadWorkspace}
 
-{docstring Lake.getRootPackage}
+{zhdocstring Lake.getRootPackage ZhDoc.BuildTools.Lake.getRootPackage}
 
-{docstring Lake.findPackageByName?}
+{zhdocstring Lake.findPackageByName? ZhDoc.BuildTools.Lake.findPackageByName?}
 
-{docstring Lake.findPackageByKey?}
+{zhdocstring Lake.findPackageByKey? ZhDoc.BuildTools.Lake.findPackageByKey?}
 
-{docstring Lake.findModule?}
+{zhdocstring Lake.findModule? ZhDoc.BuildTools.Lake.findModule?}
 
-{docstring Lake.findLeanExe?}
+{zhdocstring Lake.findLeanExe? ZhDoc.BuildTools.Lake.findLeanExe?}
 
-{docstring Lake.findLeanLib?}
+{zhdocstring Lake.findLeanLib? ZhDoc.BuildTools.Lake.findLeanLib?}
 
-{docstring Lake.findExternLib?}
+{zhdocstring Lake.findExternLib? ZhDoc.BuildTools.Lake.findExternLib?}
 
-{docstring Lake.getLeanPath}
+{zhdocstring Lake.getLeanPath ZhDoc.BuildTools.Lake.getLeanPath}
 
-{docstring Lake.getLeanSrcPath}
+{zhdocstring Lake.getLeanSrcPath ZhDoc.BuildTools.Lake.getLeanSrcPath}
 
-{docstring Lake.getSharedLibPath}
+{zhdocstring Lake.getSharedLibPath ZhDoc.BuildTools.Lake.getSharedLibPath}
 
-{docstring Lake.getAugmentedLeanPath}
+{zhdocstring Lake.getAugmentedLeanPath ZhDoc.BuildTools.Lake.getAugmentedLeanPath}
 
-{docstring Lake.getAugmentedLeanSrcPath }
+{zhdocstring Lake.getAugmentedLeanSrcPath ZhDoc.BuildTools.Lake.getAugmentedLeanSrcPath}
 
-{docstring Lake.getAugmentedSharedLibPath}
+{zhdocstring Lake.getAugmentedSharedLibPath ZhDoc.BuildTools.Lake.getAugmentedSharedLibPath}
 
-{docstring Lake.getAugmentedEnv}
+{zhdocstring Lake.getAugmentedEnv ZhDoc.BuildTools.Lake.getAugmentedEnv}

--- a/Manual/BuildTools/Lake/CLI.lean
+++ b/Manual/BuildTools/Lake/CLI.lean
@@ -19,7 +19,7 @@ open Verso.Code.External (lit)
 
 open Lean.Elab.Tactic.GuardMsgs.WhitespaceMode
 
-#doc (Manual) "Command-Line Interface" =>
+#doc (Manual) "命令行界面" =>
 %%%
 tag := "lake-cli"
 %%%
@@ -90,22 +90,22 @@ OUTPUT OPTIONS:
 See `lake help <command>` for more information on a specific command.
 ```
 
-Lake's command-line interface is structured into a series of subcommands.
-All of the subcommands share the ability to be configured by certain environment variables and global command-line options.
-Each subcommand should be understood as a utility in its own right, with its own required argument syntax and documentation.
+Lake 的命令行界面结构分为一系列子命令。
+所有的子命令都共享由特定的环境变量和全局命令行选项进行配置的能力。
+每个子命令都应被理解为一个独立的实用工具，拥有自己必需的实参语法和文档。
 
 :::paragraph
-Some of Lake's commands delegate to other command-line utilities that are not included in a Lean distribution.
-These utilities must be available on the `PATH` in order to use the corresponding features:
+一些 Lake 命令委托给了未包含在 Lean 发行版中的其他命令行实用工具。
+这些实用工具必须在 `PATH` 上可用才能使用相应的功能：
 
- * `git` is required in order to access Git dependencies.
- * `tar` is required to create or extract cloud build archives, and `curl` is required to fetch them.
- * `gh` is required to upload build artifacts to GitHub releases.
+ * 访问 Git 依赖项需要 `git`。
+ * 创建或提取云构建归档文件需要 `tar`，获取它们需要 `curl`。
+ * 将构建工件上传到 GitHub 发布版需要 `gh`。
 
-Lean distributions include a C compiler toolchain.
+Lean 发行版包含了 C 编译器工具链。
 :::
 
-# Environment Variables
+# 环境变量
 %%%
 tag := "lake-environment"
 %%%
@@ -139,118 +139,118 @@ using the form NAME=VALUE like the POSIX `env` command.
 ```
 
 
-When invoking the Lean compiler or other tools, Lake sets or modifies a number of environment variables.{index}[environment variables]
-These values are system-dependent.
-Invoking {lake}`env` without any arguments displays the environment variables and their values.
-Otherwise, the provided command is invoked in Lake's environment.
+当调用 Lean 编译器或其他工具时，Lake 会设置或修改许多环境变量。{index}[环境变量]
+这些值是与系统相关的。
+在没有任何实参的情况下调用 {lake}`env` 会显示环境变量及其值。
+否则，所提供的命令将在 Lake 的环境中被调用。
 
 ::::paragraph
-The following variables are set, overriding previous values:
+设置以下变量，覆盖之前的值：
 :::table (align := left) -header
 *
   * {envVar +def}`LAKE`
-  * The detected Lake executable
+  * 检测到的 Lake 可执行文件
 *
   * {envVar}`LAKE_HOME`
-  * The detected {tech}[Lake home]
+  * 检测到的 {tech (key := "Lake home")}[Lake 主目录]
 *
   * {envVar}`LEAN_SYSROOT`
-  * The detected Lean {tech}[toolchain] directory
+  * 检测到的 Lean {tech (key := "toolchain")}[工具链]目录
 *
  * {envVar}`LEAN_AR`
- * The detected Lean `ar` binary
+ * 检测到的 Lean `ar` 二进制文件
 *
   * {envVar}`LEAN_CC`
-  * The detected C compiler (if not using the bundled one)
+  * 检测到的 C 编译器（如果不使用绑定的编译器）
 :::
 ::::
 
 ::::paragraph
-The following variables are augmented with additional information:
+以下变量被增加了附加信息：
 :::table (align := left) -header
 *
   * {envVar}`LEAN_PATH`
-  * Lake's and the {tech}[workspace]'s Lean {tech}[library directories] are added.
+  * 添加了 Lake 的和 {tech (key := "workspace")}[工作区]的 Lean {tech (key := "library directories")}[库目录]。
 *
   * {envVar}`LEAN_SRC_PATH`
-  * Lake's and the {tech}[workspace]'s {tech}[source directories] are added.
+  * 添加了 Lake 的和 {tech (key := "workspace")}[工作区]的 {tech (key := "source directories")}[源目录]。
 *
   * {envVar}`PATH`
-  * Lean's, Lake's, and the {tech}[workspace]'s {tech}[binary directories] are added.
-    On Windows, Lean's and the {tech}[workspace]'s {tech}[library directories] are also added.
+  * 添加了 Lean 的、Lake 的和 {tech (key := "workspace")}[工作区]的 {tech (key := "binary directories")}[二进制目录]。
+    在 Windows 上，也添加了 Lean 的和 {tech (key := "workspace")}[工作区]的 {tech (key := "library directories")}[库目录]。
 *
   * {envVar}`DYLD_LIBRARY_PATH`
-  * On macOS, Lean's and the {tech}[workspace]'s {tech}[library directories] are added.
+  * 在 macOS 上，添加了 Lean 的和 {tech (key := "workspace")}[工作区]的 {tech (key := "library directories")}[库目录]。
 *
   * {envVar}`LD_LIBRARY_PATH`
-  * On platforms other than Windows and macOS, Lean's and the {tech}[workspace]'s {tech}[library directories] are added.
+  * 在除 Windows 和 macOS 之外的平台上，添加了 Lean 的和 {tech (key := "workspace")}[工作区]的 {tech (key := "library directories")}[库目录]。
 :::
 ::::
 
 ::::paragraph
-Lake itself can be configured with the following environment variables:
+可以使用以下环境变量配置 Lake 本身：
 :::table (align := left) -header
 *
   * {envVar +def}`ELAN_HOME`
-  * The location of the {ref "elan"}[Elan] installation, which is used for {ref "automatic-toolchain-updates"}[automatic toolchain updates].
+  * {ref "elan"}[Elan] 安装的位置，用于{ref "automatic-toolchain-updates"}[自动更新工具链]。
 
 *
   * {envVar +def}`ELAN`
-  * The location of the `elan` binary, which is used for {ref "automatic-toolchain-updates"}[automatic toolchain updates].
-    If it is not set, an occurrence of `elan` must exist on the {envVar}`PATH`.
+  * `elan` 二进制文件的位置，用于{ref "automatic-toolchain-updates"}[自动更新工具链]。
+    如果未设置，`elan` 必须在 {envVar}`PATH` 上存在。
 
 *
   * {envVar +def}`LAKE_HOME`
-  * The location of the Lake installation.
-    This environment variable is only consulted when Lake is unable to determine its installation path from the location of the `lake` executable that's currently running.
+  * Lake 安装的位置。
+    只有当 Lake 无法从当前运行的 `lake` 可执行文件的位置确定其安装路径时，才会查询此环境变量。
 *
   * {envVar +def}`LEAN_SYSROOT`
-  * The location of the Lean installation, used to find the Lean compiler, the standard library, and other bundled tools.
-    Lake first checks whether its binary is colocated with a Lean install, using that installation if so.
-    If not, or if {envVar +def}`LAKE_OVERRIDE_LEAN` is true, then Lake consults {envVar}`LEAN_SYSROOT`.
-    If this is not set, Lake consults the {envVar +def}`LEAN` environment variable to find the Lean compiler, and attempts to find the Lean installation relative to the compiler.
-    If {envVar}`LEAN` is set but empty, Lake considers Lean to be disabled.
-    If {envVar}`LEAN_SYSROOT` and {envVar}`LEAN` are unset, the first occurrence of `lean` on the {envVar}`PATH` is used to find the installation.
+  * Lean 安装的位置，用于查找 Lean 编译器、标准库和其他绑定工具。
+    Lake 首先检查其二进制文件是否与 Lean 安装位于同一位置，如果是则使用该安装。
+    如果不是，或者 {envVar +def}`LAKE_OVERRIDE_LEAN` 为 true，那么 Lake 会查询 {envVar}`LEAN_SYSROOT`。
+    如果未设置此变量，Lake 会查询 {envVar +def}`LEAN` 环境变量以查找 Lean 编译器，并尝试查找相对于编译器的 Lean 安装。
+    如果设置了 {envVar}`LEAN` 但为空，Lake 将认为 Lean 已被禁用。
+    如果未设置 {envVar}`LEAN_SYSROOT` 和 {envVar}`LEAN`，则使用 {envVar}`PATH` 上的第一个 `lean` 来查找安装。
 *
-  * {envVar +def}`LEAN_CC` and {envVar +def}`LEAN_AR`
-  * If {envVar}`LEAN_CC` and/or {envVar}`LEAN_AR` is set, its value is used as the C compiler or `ar` command when building libraries.
-    If not, Lake will fall back to the bundled tool in the Lean installation.
-    If the bundled tool is not found, the value of {envVar +def}`CC` or {envVar +def}`AR`, followed by a `cc` or `ar` on the {envVar}`PATH`, are used.
+  * {envVar +def}`LEAN_CC` 和 {envVar +def}`LEAN_AR`
+  * 如果设置了 {envVar}`LEAN_CC` 和/或 {envVar}`LEAN_AR`，其值将在构建库时用作 C 编译器或 `ar` 命令。
+    如果没有设置，Lake 将回退到 Lean 安装中的绑定工具。
+    如果找不到绑定工具，将使用 {envVar +def}`CC` 或 {envVar +def}`AR` 的值，接着是 {envVar}`PATH` 上的 `cc` 或 `ar`。
 *
   * {envVar +def}`LAKE_NO_CACHE`
-  * If true, Lake does not use cached builds from [Reservoir](https://reservoir.lean-lang.org/) or {ref "lake-github"}[GitHub].
-    This environment variable can be overridden using the {lakeOpt}`--try-cache` command-line option.
+  * 如果为 true，Lake 不使用来自 [Reservoir](https://reservoir.lean-lang.org/) 或 {ref "lake-github"}[GitHub] 的缓存构建。
+    可以使用 {lakeOpt}`--try-cache` 命令行选项覆盖此环境变量。
 
 *
   * {envVar +def}`LAKE_ARTIFACT_CACHE`
-  * If true, Lake uses the artifact cache.
-    This is an experimental feature.
+  * 如果为 true，Lake 将使用工件缓存。
+    这是一个实验性功能。
 
 *
   * {envVar +def}`LAKE_CACHE_KEY`
-  * Defines an authentication key for the {ref "lake-cache-remote"}[remote artifact cache].
+  * 为{ref "lake-cache-remote"}[远程工件缓存]定义认证密钥。
 
 *
   * {envVar +def}`LAKE_CACHE_ARTIFACT_ENDPOINT`
-  * The base URL for the {ref "lake-cache-remote"}[remote artifact cache] used for artifact uploads.
-    If set, then {envVar}`LAKE_CACHE_REVISION_ENDPOINT` must also be set.
-    If neither of these are set, Lake will use Reservoir instead.
+  * 用于工件上传的{ref "lake-cache-remote"}[远程工件缓存]的基准 URL。
+    如果设置了此变量，则还必须设置 {envVar}`LAKE_CACHE_REVISION_ENDPOINT`。
+    如果两者都未设置，Lake 将使用 Reservoir。
 
 *
   * {envVar +def}`LAKE_CACHE_REVISION_ENDPOINT`
-  * The base URL for the {ref "lake-cache-remote"}[remote artifact cache] used to upload the {tech (key := "mappings file")}[input/output mappings] for each artifact.
-    If set, then {envVar}`LAKE_CACHE_ARTIFACT_ENDPOINT` must also be set.
-    If neither of these are set, Lake will use Reservoir instead.
+  * 用于为每个工件上传 {tech (key := "mappings file")}[输入/输出映射]的{ref "lake-cache-remote"}[远程工件缓存]的基准 URL。
+    如果设置了此变量，则还必须设置 {envVar}`LAKE_CACHE_ARTIFACT_ENDPOINT`。
+    如果两者都未设置，Lake 将使用 Reservoir。
 
 :::
 ::::
 
-Lake considers an environment variable to be true when its value is `y`, `yes`, `t`, `true`, `on`, or `1`, compared case-insensitively.
-It considers a variable to be false when its value is `n`, `no`, `f`, `false`, `off`, or `0`, compared case-insensitively.
-If the variable is unset, or its value is neither true nor false, a default value is used.
+Lake 将值为 `y`、`yes`、`t`、`true`、`on` 或 `1`（不区分大小写）的环境变量视为 true。
+它将值为 `n`、`no`、`f`、`false`、`off` 或 `0`（不区分大小写）的变量视为 false。
+如果变量未设置，或者其值既不为 true 也不为 false，则使用默认值。
 
 ```lean -show
--- Test the claim above
+-- 测试上述断言
 /--
 info: def Lake.envToBool? : String → Option Bool :=
 fun o =>
@@ -261,151 +261,151 @@ fun o =>
 #print Lake.envToBool?
 ```
 
-# Options
+# 选项
 
-Lake's command-line interface provides a number of global options as well as subcommands that perform important tasks.
-Single-character flags cannot be combined; `-HR` is not equivalent to `-H -R`.
+Lake 的命令行界面提供了许多全局选项以及执行重要任务的子命令。
+单字符标志不能组合；`-HR` 不等于 `-H -R`。
 
 : {lakeOptDef flag}`--version`
 
-  Lake outputs its version and exits without doing anything else.
+  Lake 输出其版本并退出，不执行任何其他操作。
 
-: {lakeOptDef flag}`--help` or {lakeOptDef flag}`-h`
+: {lakeOptDef flag}`--help` 或 {lakeOptDef flag}`-h`
 
-  Lake outputs its version along with usage information and exits without doing anything else.
-  Subcommands may be used with {lakeOpt}`--help`, in which case usage information for the subcommand is output.
+  Lake 输出其版本以及使用信息并退出，不执行任何其他操作。
+  子命令可以与 {lakeOpt}`--help` 一起使用，在这种情况下将输出该子命令的使用信息。
 
-: {lakeOptDef option}`--dir DIR` or {lakeOptDef option}`-d=DIR`
+: {lakeOptDef option}`--dir DIR` 或 {lakeOptDef option}`-d=DIR`
 
-  Use the provided directory as location of the package instead of the current working directory.
-  This is not always equivalent to changing to the directory first, because the version of `lake` indicated by the current directory's {tech}[toolchain file] will be used, rather than that of `DIR`.
+  将提供的目录而不是当前工作目录用作包的位置。
+  这并不总是等同于先更改到该目录，因为会使用当前目录的{tech (key := "toolchain file")}[工具链文件]指示的 `lake` 版本，而不是 `DIR` 的版本。
 
-: {lakeOptDef option}`--file FILE` or {lakeOptDef option}`-f=FILE`
+: {lakeOptDef option}`--file FILE` 或 {lakeOptDef option}`-f=FILE`
 
-  Use the specified {tech}[package configuration] file instead of the default.
+  使用指定的{tech (key := "package configuration")}[包配置]文件而不是默认文件。
 
 : {lakeOptDef flag}`--old`
 
-  Only rebuild modified modules, ignoring transitive dependencies.
-  Modules that import the modified module will not be rebuilt.
-  In order to accomplish this, file modification times are used instead of hashes to determine whether a module has changed.
+  仅重新构建修改的模块，忽略传递依赖项。
+  导入修改模块的模块将不会被重新构建。
+  为了实现这一点，将使用文件修改时间而不是哈希来确定模块是否已更改。
 
-: {lakeOptDef flag}`--rehash` or {lakeOptDef flag}`-H`
+: {lakeOptDef flag}`--rehash` 或 {lakeOptDef flag}`-H`
 
-  Ignore cached file hashes, recomputing them.
-  Lake uses hashes of dependencies to determine whether to rebuild an artifact.
-  These hashes are cached on disk whenever a module is built.
-  To save time during builds, these cached hashes are used instead of recomputing each hash unless {lakeOpt}`--rehash` is specified.
+  忽略缓存的文件哈希，重新计算它们。
+  Lake 使用依赖项的哈希来确定是否重新构建工件。
+  每当构建模块时，这些哈希都会缓存在磁盘上。
+  为了在构建过程中节省时间，除非指定了 {lakeOpt}`--rehash`，否则会使用这些缓存的哈希，而不是重新计算每个哈希。
 
 : {lakeOptDef flag}`--allow-empty`
 
-  Accept builds that produce no output when no {tech}[default targets] are configured.
+  接受在未配置{tech (key := "default targets")}[默认目标]时产生无输出的构建。
 
 : {lakeOptDef flag}`--update`
 
-  Update dependencies after the {tech}[package configuration] is loaded but prior to performing other tasks, such as a build.
-  This is equivalent to running `lake update` before the selected command, but it may be faster due to not having to load the configuration twice.
+  在加载{tech (key := "package configuration")}[包配置]之后、但在执行其他任务（例如构建）之前更新依赖项。
+  这等同于在选定命令之前运行 `lake update`，但由于不需要加载配置两次，它可能会更快。
 
 : {lakeOptDef option}`--packages=FILE`
 
-  Uses the specified {tech}[package overrides] file.
-  Can be specified multiple times to add more overrides (with later overrides taking precedence).
-  The complete set of package overrides will also include those from `.lake/package-overrides.json` (if any).
-  However, the ones provided by this option take precedence.
+  使用指定的{tech (key := "package overrides")}[包覆盖]文件。
+  可以多次指定此选项以添加更多覆盖（后指定的覆盖优先）。
+  包覆盖的完整集合还将包括来自 `.lake/package-overrides.json` 的覆盖（如果有）。
+  但是，通过此选项提供的覆盖具有更高的优先级。
 
-:  {lakeOptDef flag}`--reconfigure` or {lakeOptDef flag}`-R`
+:  {lakeOptDef flag}`--reconfigure` 或 {lakeOptDef flag}`-R`
 
-  Normally, the {tech}[package configuration] file is {tech (key := "elaborator") -normalize}[elaborated] when a package is first configured, with the result cached to a {tech}[`.olean` file] that is used for future invocations until the package configuration
-  Providing this flag causes the configuration file to be re-elaborated.
+  通常，{tech (key := "package configuration")}[包配置]文件在首次配置包时由{tech (key := "elaborator") -normalize}[精译器处理]，并将结果缓存到供将来调用使用的 {tech (key := ".olean file")}[`.olean` 文件]中，直到包配置发生更改。
+  提供此标志将导致配置文件被重新精译。
 
 : {lakeOptDef flag}`--keep-toolchain`
 
-  By default, Lake attempts to update the local {tech}[workspace]'s {tech}[toolchain file].
-  Providing this flag disables {ref "automatic-toolchain-updates"}[automatic toolchain updates].
+  默认情况下，Lake 会尝试更新本地{tech (key := "workspace")}[工作区]的{tech (key := "toolchain file")}[工具链文件]。
+  提供此标志会禁用{ref "automatic-toolchain-updates"}[自动更新工具链]。
 
 : {lakeOptDef flag}`--no-build`
 
-  Lake exits immediately if a build target is not up-to-date, returning a non-zero exit code.
+  如果构建目标不是最新的，Lake 会立即退出，并返回非零的退出代码。
 
 : {lakeOptDef flag}`--no-cache`
 
-  Instead of using available cloud build caches, build all packages locally.
-  Build caches are not downloaded.
+  不使用可用的云构建缓存，而是在本地构建所有包。
+  构建缓存不被下载。
 
 : {lakeOptDef flag}`--try-cache`
 
-  attempt to download build caches for supported packages
+  尝试下载支持的包的构建缓存
 
-# Controlling Output
+# 控制输出
 
-These options provide allow control over the {tech}[log] that is produced while building.
-In addition to showing or hiding messages, a build can be made to fail when warnings or even information is emitted; this can be used to enforce a style guide that disallows output during builds.
+这些选项允许控制在构建时生成的{tech (key := "log")}[日志]。
+除了显示或隐藏消息之外，还可以使构建在发出警告甚至信息时失败；这可用于强制实施不允许在构建期间输出的风格指南。
 
 : {lakeOptDef flag}`--quiet`, {lakeOptDef flag}`-q`
 
-  Hides informational logs and the progress indicator.
+  隐藏信息日志和进度指示器。
 
 : {lakeOptDef flag}`--verbose`, {lakeOptDef flag}`-v`
 
-  Shows trace logs (typically command invocations) and built {tech}[targets].
+  显示跟踪日志（通常是命令调用）和构建的{tech (key := "targets")}[目标]。
 
 :  {lakeOptDef flag}`--ansi`, {lakeOptDef flag}`--no-ansi`
 
-  Enables or disables the use of [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code) that add colors and animations to Lake's output.
+  启用或禁用使用为 Lake 的输出添加颜色和动画的 [ANSI 转义码](https://en.wikipedia.org/wiki/ANSI_escape_code)。
 
 :  {lakeOptDef option}`--log-level=LV`
 
-  Sets the minimum level of {tech}[logs] to be shown when builds succeed.
-  `LV` may be `trace`, `info`, `warning`, or `error`, compared case-insensitively.
-  When a build fails, all levels are shown.
-  The default log level is `info`.
+  设置在构建成功时要显示的{tech (key := "logs")}[日志]的最低级别。
+  `LV` 可以是 `trace`、`info`、`warning` 或 `error`，不区分大小写。
+  当构建失败时，会显示所有级别。
+  默认日志级别为 `info`。
 
 :  {lakeOptDef option}`--fail-level=LV`
 
-  Sets the threshold at which a message in the {tech}[log] causes a build to be considered a failure.
-  If a message is emitted to the log with a level that is greater than or equal to the threshold, the build fails.
-  `LV` may be `trace`, `info`, `warning`, or `error`, compared case-insensitively; it is `error` by default.
+  设置导致构建被视为失败的{tech (key := "log")}[日志]消息级别阈值。
+  如果在日志中发出的消息级别大于或等于该阈值，构建将失败。
+  `LV` 可以是 `trace`、`info`、`warning` 或 `error`，不区分大小写；默认为 `error`。
 
 
 : {lakeOptDef flag}`--iofail`
 
-  Causes builds to fail if any I/O or other info is logged.
-  This is equivalent to {lakeOpt}`--fail-level=info`.
+  如果记录了任何 I/O 或其他信息，则导致构建失败。
+  这等同于 {lakeOpt}`--fail-level=info`。
 
 : {lakeOptDef flag}`--wfail`
 
-  Causes builds to fail if any warnings are logged.
-  This is equivalent to {lakeOpt}`--fail-level=warning`.
+  如果记录了任何警告，则导致构建失败。
+  这等同于 {lakeOpt}`--fail-level=warning`。
 
-# Automatic Toolchain Updates
+# 自动更新工具链
 %%%
 tag := "automatic-toolchain-updates"
 %%%
 
-The {lake}`update` command checks for changes to dependencies, fetching their sources and updating the {tech}[manifest] accordingly.
-By default, {lake}`update` also attempts to update the {tech}[root package]'s {tech}[toolchain file] when a new version of a dependency specifies an updated toolchain.
-This behavior can be disabled with the {lakeOpt}`--keep-toolchain` flag.
+{lake}`update` 命令检查依赖项的更改，获取其源代码并相应地更新{tech (key := "manifest")}[清单]。
+默认情况下，当依赖项的新版本指定了更新的工具链时，{lake}`update` 还会尝试更新{tech (key := "root package")}[根包]的{tech (key := "toolchain file")}[工具链文件]。
+可以使用 {lakeOpt}`--keep-toolchain` 标志禁用此行为。
 
 :::paragraph
-If multiple dependencies specify newer toolchains, Lake selects the newest compatible toolchain, if it exists.
-To determine the newest compatible toolchain, Lake parses the toolchain listed in the packages' `lean-toolchain` files into four categories:
+如果多个依赖项指定了较新的工具链，Lake 将选择最新的兼容工具链（如果存在）。
+为了确定最新的兼容工具链，Lake 将包的 `lean-toolchain` 文件中列出的工具链解析为四类：
 
- * Releases, which are compared by version number (e.g., `v4.4.0` < `v4.8.0` and `v4.6.0-rc1` < `v4.6.0`)
- * Nightly builds, which are compared by date (e.g., `nightly-2024-01-10` < `nightly-2024-10-01`)
- * Builds from pull requests to the Lean compiler, which are incomparable
- * Other versions, which are also incomparable
+ * 发布版，按版本号进行比较（例如，`v4.4.0` < `v4.8.0` 和 `v4.6.0-rc1` < `v4.6.0`）
+ * 每日构建版，按日期进行比较（例如，`nightly-2024-01-10` < `nightly-2024-10-01`）
+ * 针对 Lean 编译器的拉取请求构建，不可比较
+ * 其他版本，同样不可比较
 
-Toolchain versions from multiple categories are incomparable.
-If there is not a single newest toolchain, Lake will print a warning and continue updating without changing the toolchain.
+来自多个类别的工具链版本是不可比较的。
+如果没有唯一的最新的工具链，Lake 将打印警告并继续更新，而不更改工具链。
 :::
 
-If Lake does find a new toolchain, then it updates the {tech}[workspace]'s `lean-toolchain` file accordingly and restarts the {lake}`update` using the new toolchain's Lake.
-If {ref "elan"}[Elan] is detected, it will spawn the new Lake process via `elan run` with the same arguments Lake was initially run with.
-If Elan is missing, it will prompt the user to restart Lake manually and exit with a special error code (namely, `4`).
-The Elan executable used by Lake can be configured using the {envVar}`ELAN` environment variable.
+如果 Lake 确实找到了新的工具链，那么它会相应地更新{tech (key := "workspace")}[工作区]的 `lean-toolchain` 文件，并使用新工具链的 Lake 重新启动 {lake}`update`。
+如果检测到 {ref "elan"}[Elan]，它将通过 `elan run` 启动新的 Lake 进程，并使用最初运行 Lake 时的相同参数。
+如果缺少 Elan，它将提示用户手动重新启动 Lake，并退出特殊的错误代码（即 `4`）。
+可以使用 {envVar}`ELAN` 环境变量配置 Lake 使用的 Elan 可执行文件。
 
 
-# Creating Packages
+# 创建包
 
 ```lakeHelp "new"
 Create a Lean package in a new directory
@@ -430,42 +430,42 @@ version of the configuration file, respectively. The default is TOML.
 
 :::lake new "name [template][\".\"language]"
 
-Running {lake}`new` creates an initial Lean package in a new directory.
-This command is equivalent to creating a directory named {lakeMeta}`name` and then running {lake}`init`
+运行 {lake}`new` 将在新目录中创建一个初始的 Lean 包。
+此命令等同于创建一个名为 {lakeMeta}`name` 的目录，然后运行 {lake}`init`。
 
 :::
 
 :::lake init "name [template][\".\"language]"
 
-Running {lake}`init` creates an initial Lean package in the current directory.
-The package's contents are based on a template, with the names of the {tech}[package], its {tech}[targets], and their {tech}[module roots] derived from the name of the current directory.
+运行 {lake}`init` 将在当前目录中创建一个初始的 Lean 包。
+包的内容基于模板，其{tech (key := "package")}[包]的名称、{tech (key := "targets")}[目标]及其{tech (key := "module roots")}[模块根]来自当前目录的名称。
 
-The {lakeMeta}`template` may be:
+{lakeMeta}`template` 可以是：
 
-: `std` (default)
+: `std`（默认）
 
-  Creates a package that contains a library and an executable.
+  创建一个包含库和可执行文件的包。
 
 : `exe`
 
-  Creates a package that contains only an executable.
+  创建一个仅包含可执行文件的包。
 
 : `lib`
 
-  Creates a package that contains only a library.
+  创建一个仅包含库的包。
 
 : `math`
 
-  Creates a package that contains a library that depends on [Mathlib](https://github.com/leanprover-community/mathlib4).
+  创建一个包含依赖于 [Mathlib](https://github.com/leanprover-community/mathlib4) 库的包。
 
-The {lakeMeta}`language` selects the file format used for the {tech}[package configuration] file and may be `lean` (the default) or `toml`.
+{lakeMeta}`language` 选择用于{tech (key := "package configuration")}[包配置]文件的文件格式，可以是 `lean`（默认）或 `toml`。
 :::
 
 :::TODO
-Example of `lake init` or `lake new`
+`lake init` 或 `lake new` 的示例
 :::
 
-# Building and Running
+# 构建与运行
 
 ```lakeHelp "build"
 Build targets
@@ -525,49 +525,49 @@ mappings can then be used to upload build artifacts to a remote cache with
 
 ::::lake build "[targets...] [\"-o\" mappings]"
 
-Builds the specified facts of the specified targets.
+构建指定的目标的指定分面。
 
-Each of the {lakeMeta}`targets` is specified by a string of the form:
+每个 {lakeMeta}`targets` 都是通过以下形式的字符串指定的：
 
 {lakeArgs}`[["@"]package["/"]][target|["+"]module][":"facet]`
 
-The optional {keyword}`@` and {keyword}`+` markers can be used to disambiguate packages and modules from file paths as well as executables, and libraries, which are specified by name as {lakeMeta}`target`.
-If not provided, {lakeMeta}`package` defaults to the {tech}[workspace]'s {tech}[root package].
-If the same target name exists in multiple packages in the workspace, then the first occurrence of the target name found in a topological sort of the package dependency graph is selected.
-Module targets may also be specified by their filename, with an optional facet after a colon.
+可选的 {keyword}`@` 和 {keyword}`+` 标记可用于将包和模块与文件路径以及通过按名称作为 {lakeMeta}`target` 指定的可执行文件和库区分开来。
+如果未提供，{lakeMeta}`package` 默认为{tech (key := "workspace")}[工作区]的{tech (key := "root package")}[根包]。
+如果工作区中的多个包中存在相同的目标名称，则选择在包依赖关系图的拓扑排序中找到的目标名称的第一次出现。
+模块目标也可以由它们的文件名指定，在冒号之后带有可选的分面。
 
-The available {tech}[facets] depend on whether a package, library, executable, or module is to be built.
-They are listed in {ref "lake-facets"}[the section on facets].
+可用的{tech (key := "facets")}[分面]取决于要构建的是包、库、可执行文件还是模块。
+它们在{ref "lake-facets"}[关于分面的部分]中列出。
 
-When using the {ref "lake-cache"}[local artifact cache], the {lakeOptDef option}`-o` option saves a {tech}[mappings file] that tracks the inputs and outputs of each step in the build.
-This file can be used with {lake}`cache get` and {lake}`cache put` to interact with a remote cache.
-The mappings file is in JSON Lines format, with one valid JSON object per line, and its filename extension is conventionally `.jsonl`.
+当使用{ref "lake-cache"}[本地工件缓存]时，{lakeOptDef option}`-o` 选项将保存一个跟踪构建每一步的输入和输出的{tech (key := "mappings file")}[映射文件]。
+此文件可与 {lake}`cache get` 和 {lake}`cache put` 一起使用以与远程缓存进行交互。
+映射文件采用 JSON Lines 格式，每行一个有效的 JSON 对象，通常文件扩展名为 `.jsonl`。
 ::::
 
-::::example "Target and Facet Specifications"
+::::example "目标和分面规范" (file := "Target and Facet Specifications")
 
 :::table
 *
   - `a`
-  - The {tech}[default facet](s) of target `a`
+  - 目标 `a` 的{tech (key := "default facet")}[默认分面]
 *
   - `@a`
-  - The {tech}[default targets] of {tech}[package] `a`
+  - {tech (key := "package")}[包] `a` 的{tech (key := "default targets")}[默认目标]
 *
   - `+A`
-  -  The Lean artifacts of module `A` (because the default facet of modules is `leanArts`)
+  -  模块 `A` 的 Lean 工件（因为模块的默认分面是 `leanArts`）
 *
   - `@a/b`
-  - The default facet of target `b` of package `a`
+  - 包 `a` 的目标 `b` 的默认分面
 *
   - `@a/+A:c`
-  - The C file compiled from module `A` of package `a`
+  - 从包 `a` 的模块 `A` 编译的 C 文件
 *
   - `:foo`
-  - The {tech}[root package]'s facet `foo`
+  - {tech (key := "root package")}[根包]的分面 `foo`
 *
   - `A/B/C.lean:o`
-  - The compiled object code for the module in the file `A/B/C.lean`
+  - 文件 `A/B/C.lean` 中模块的编译目标代码
 :::
 ::::
 
@@ -586,11 +586,11 @@ It merely verifies that some are specified.
 ```
 
 :::lake «check-build»
-Exits with code 0 if the {tech}[workspace]'s {tech}[root package] has any {tech}[default targets] configured.
-Errors (with exit code 1) otherwise.
+如果{tech (key := "workspace")}[工作区]的{tech (key := "root package")}[根包]配置了任何{tech (key := "default targets")}[默认目标]，则以状态码 0 退出。
+否则报错（退出代码 1）。
 
-{lake}`check-build` does *not* verify that the configured default targets are valid.
-It merely verifies that at least one is specified.
+{lake}`check-build` *不*验证配置的默认目标是否有效。
+它仅仅验证至少指定了一个。
 :::
 
 ```lakeHelp "exe"
@@ -623,23 +623,22 @@ See `lake help build` for information on and examples of targets.
 ```
 
 :::lake query "[targets...]"
-Builds a set of targets, reporting progress on standard error and outputting the results on standard out.
-Target results are output in the same order they are listed and end with a newline.
-If `--json` is set, results are formatted as JSON.
-Otherwise, they are printed as raw strings.
+构建一组目标，在标准错误上报告进度，并在标准输出上输出结果。
+目标结果按照它们列出的顺序输出，并以换行符结束。
+如果设置了 `--json`，结果将格式化为 JSON。
+否则，它们将被打印为原始字符串。
 
-Targets which do not have output configured will be printed as an empty string or `null`.
-For executable targets, the output is the path to the built executable.
+未配置输出的目标将被打印为空字符串或 `null`。
+对于可执行目标，输出是已构建可执行文件的路径。
 
-Targets are specified using the same syntax as in {lake}`build`.
+使用与 {lake}`build` 相同的语法指定目标。
 :::
 
 :::lake exe "«exe-target» [args...]" (alias := exec)
 
-Looks for the executable target {lakeMeta}`exe-target` in the workspace, builds it if it is out of date, and then runs
-it with the given {lakeMeta}`args` in Lake's environment.
+在工作区中查找可执行目标 {lakeMeta}`exe-target`，如果过期则构建它，然后在 Lake 的环境中使用给定的 {lakeMeta}`args` 运行它。
 
-See {lake}`build` for the syntax of target specifications and {lake}`env` for a description of how the environment is set up.
+有关目标规范的语法，请参见 {lake}`build`，有关如何设置环境的描述，请参见 {lake}`env`。
 
 :::
 
@@ -655,8 +654,8 @@ the workspace. Otherwise, just deletes those of the specified packages.
 
 :::lake clean "[packages...]"
 
-If no package is specified, deletes the {tech}[build directories] of every package in the workspace.
-Otherwise, it just deletes those of the specified {lakeMeta}`packages`.
+如果没有指定包，则删除工作区中每个包的{tech (key := "build directories")}[构建目录]。
+否则，它只删除指定的 {lakeMeta}`packages` 的构建目录。
 
 :::
 
@@ -690,10 +689,10 @@ using the form NAME=VALUE like the POSIX `env` command.
 
 ::::lake env "[cmd [args...]]"
 
-When {lakeMeta}`cmd` is provided, it is executed in {ref "lake-environment"}[the Lake environment] with arguments {lakeMeta}`args`.
+当提供了 {lakeMeta}`cmd` 时，它将在带有实参 {lakeMeta}`args` 的{ref "lake-environment"}[Lake 环境]中执行。
 
-If {lakeMeta}`cmd` is not provided, Lake prints the environment in which it runs tools.
-This environment is system-specific.
+如果没有提供 {lakeMeta}`cmd`，Lake 将打印其运行工具的环境。
+这个环境是特定于系统的。
 ::::
 
 ```lakeHelp "lean"
@@ -710,11 +709,11 @@ the workspace's root package's additional Lean arguments and the given args
 
 :::lake lean "file [\"--\" args...]"
 
-Builds the imports of the given {lakeMeta}`file` and then runs `lean` on it using the {tech}[workspace]'s {tech}[root package]'s additional Lean arguments and the given {lakeMeta}`args`, in that order.
-The `lean` process is executed in {ref "lake-environment"}[Lake's environment].
+构建给定的 {lakeMeta}`file` 的导入，然后在此文件上使用{tech (key := "workspace")}[工作区]的{tech (key := "root package")}[根包]的其他 Lean 实参和给定的 {lakeMeta}`args`（按此顺序）运行 `lean`。
+`lean` 进程在{ref "lake-environment"}[Lake 的环境]中执行。
 :::
 
-# Module Imports
+# 模块导入
 
 ```lakeHelp shake
 Minimize imports in Lean source files
@@ -757,70 +756,70 @@ ANNOTATIONS:
 
 ::::lake shake "[options...] [module ...]"
 
-Checks the current project for unused imports by analyzing generated {tech}[`.olean` files] to deduce required imports, ensuring that every import contributes some constant or other elaboration dependency.
+通过分析生成的 {tech (key := ".olean files")}[`.olean` 文件]推断所需的导入，检查当前项目中未使用的导入，确保每个导入都有助于某些常量或其他精译依赖项。
 
-If a {lakeMeta}`module` is specified, then it and all files that are transitively reachable from it are checked. Otherwise, the package's {tech}[default targets] are checked.
+如果指定了 {lakeMeta}`module`，则将检查它及其可传递访问的所有文件。否则，将检查包的{tech (key := "default targets")}[默认目标]。
 
 :::paragraph
-Source files can contain special comments to control the behavior of {lake}`shake`:
+源文件可以包含特殊的注释来控制 {lake}`shake` 的行为：
 
 : `module -- shake: keep-downstream`
 
-  Preserves this module in all downstream modules.
+  在所有下游模块中保留此模块。
 
 : `module -- shake: keep-all`
 
-  Preserves all existing imports in this module.
+  保留此模块中的所有现有导入。
 
 : `import X -- shake: keep`
 
-  Preserves this specific import.
+  保留此特定的导入。
 :::
 
 :::paragraph
-The {lakeMeta}`options` may be:
+{lakeMeta}`options` 可以是：
 
 : `--force`
 
-  Skip the `lake build --no-build` sanity check
+  跳过 `lake build --no-build` 健全性检查
 
 : `--keep-implied`
 
-  Preserve imports implied by other imports
+  保留由其他导入隐含的导入
 
 : `--keep-prefix`
 
-  Prefer parent module imports over specific submodules
+  倾向于父模块导入而不是特定的子模块
 
 : `--keep-public`
 
-  Preserve all `public` imports for API stability
+  保留所有的 `public` 导入以保持 API 稳定性
 
 : `--add-public`
 
-  Add new imports as `public` if they were in the original public closure
+  如果新导入原本在公开闭包中，则将其添加为 `public`
 
 : `--explain`
 
-  Show which constants require each import
+  显示哪些常量需要每次导入
 
 : `--fix`
 
-  Apply suggested fixes directly to source files
+  直接将建议的修复应用到源文件
 
 : `--gh-style`
 
-  Output in GitHub problem matcher format
+  以 GitHub 问题匹配器格式输出
 :::
 
 ::::
 
-# Development Tools
+# 开发工具
 
-Lake includes support for specifying standard development tools and workflows.
-On the command line, these tools can be invoked using the appropriate `lake` subcommands.
+Lake 包含了对指定标准开发工具和工作流的支持。
+在命令行上，可以使用适当的 `lake` 子命令调用这些工具。
 
-## Tests and Linters
+## 测试和代码检查
 
 ```lakeHelp test
 Test the workspace's root package using its configured test driver
@@ -840,11 +839,11 @@ built and then run like a script. A library test driver will just be built.
 ```
 
 :::lake test " [\"--\" args...]"
-Test the workspace's root package using its configured {tech}[test driver].
+使用其配置的{tech (key := "test driver")}[测试驱动程序]测试工作区的根包。
 
-A test driver that is an executable will be built and then run with the package configuration's `testDriverArgs` plus the CLI {lakeMeta}`args`.
-A test driver that is a {tech}[Lake script] is run with the same arguments as an executable test driver.
-A library test driver will just be built; it is expected that tests are implemented such that failures cause the build to fail via elaboration-time errors.
+作为可执行文件的测试驱动程序将被构建，然后使用包配置的 `testDriverArgs` 加上 CLI 的 {lakeMeta}`args` 运行。
+作为{tech (key := "Lake script")}[Lake 脚本]的测试驱动程序使用与可执行文件测试驱动程序相同的实参运行。
+库测试驱动程序只会进行构建；预期实现测试的方式是，失败会通过精译期错误导致构建失败。
 :::
 
 ```lakeHelp lint
@@ -908,57 +907,57 @@ built and then run like a script.
 ```
 
 ```comment
-We're intentionally leaving out --code-quality until it is more developed
+我们有意地在 --code-quality 得到进一步开发之前将其省略
 ```
 
 :::lake lint "[options...] [module...] [\"--\" args...]"
 
-By default, lint the workspace's root package using its configured lint driver.
-If {tomlField Lake.PackageConfig}`builtinLint` is set to {name}`true` in the package configuration, builtin lints also run.
+默认情况下，使用工作区配置的代码检查驱动程序对其根包执行代码检查。
+如果在包配置中将 {tomlField Lake.PackageConfig}`builtinLint` 设置为 {name}`true`，也会运行内置代码检查。
 
-Positional {lakeMeta}`module` arguments narrow only the builtin lints; if omitted, the workspace's default target roots are used.
-The lint driver is invoked with `lintDriverArgs` from the package config plus any arguments after `--`; the {lakeMeta}`module` list is not passed to it.
+位置实参 {lakeMeta}`module` 仅用于缩减内置代码检查 的范围；如果省略，则使用工作区的默认目标根。
+调用 代码检查驱动程序时会使用包配置中的 `lintDriverArgs` 以及位于 `--` 之后的任何实参；{lakeMeta}`module` 列表不会传递给它。
 
-Builtin linting builds the targeted modules with the requested linter options enabled.
-It is triggered by {lakeOpt}`--builtin-lint`, {lakeOpt}`--builtin-only`, {lakeOpt}`--linters`, or {lakeOpt}`--lint-only`, as well as by setting `builtinLint` to {name}`true` in the package configuration.
-By contrast, running the lint driver does not automatically trigger a build of anything but the lint driver itself.
+内置代码检查会在启用了要求的 代码检查器选项的情况下构建目标模块。
+它可以通过 {lakeOpt}`--builtin-lint`、{lakeOpt}`--builtin-only`、{lakeOpt}`--linters`、{lakeOpt}`--lint-only`，或者在包配置中将 `builtinLint` 设置为 {name}`true` 来触发。
+相比之下，运行 代码检查驱动程序本身并不会自动触发除了 代码检查驱动程序自身以外的任何构建。
 
-The set of environment linters to be run on a declaration is determined by the linter options that were in effect when that declaration was built, whether they were set by `set_option` in the source or on the command line.
-Both {lakeOpt}`--linters` and {lakeOpt}`--lint-only` override those options for the lint build.
+要在某个声明上运行的一组环境代码检查器 由构建该声明时生效的 代码检查器选项决定，不论是通过源文件中的 `set_option` 还是命令行设置的。
+{lakeOpt}`--linters` 和 {lakeOpt}`--lint-only` 都在执行 代码检查构建时覆盖了这些选项。
 
-The {lakeMeta}`options` may be:
+{lakeMeta}`options` 可以是：
 
 : {lakeOptDef flag}`--builtin-lint`
 
-  Run builtin environment and text linters.
+  运行内置的环境和文本代码检查器。
 
 : {lakeOptDef flag}`--builtin-only`
 
-  Run only builtin linters, skipping the lint driver.
+  仅运行内置代码检查器，跳过 代码检查驱动程序。
 
 : {lakeOptDef option}`--linters` {lakeMeta}`<spec>`
 
-  Override linter options for the lint build.
-  The {lakeMeta}`<spec>` is a comma-separated list of linter option names, each optionally prefixed with `-` to disable it.
-  A name that begins with `.` is shorthand for the `linter.` prefix, so that `.foo` means `linter.foo`, as in `--linters=.foo,-linter.bar`.
-  This option may be repeated; for a given linter, later entries override earlier ones.
+  覆盖 代码检查构建的 代码检查器选项。
+  {lakeMeta}`<spec>` 是一个逗号分隔的 代码检查器选项名称列表，每个选项前可以选择带有 `-` 以禁用它。
+  以 `.` 开头的名称是 `linter.` 前缀的简写，因此 `.foo` 表示 `linter.foo`，正如 `--linters=.foo,-linter.bar` 那样。
+  此选项可以重复；对于给定的代码检查器，后面的条目会覆盖前面的。
 
 : {lakeOptDef option}`--lint-only` {lakeMeta}`<spec>`
 
-  Like {lakeOpt}`--linters`, but report only the linters that {lakeMeta}`<spec>` positively enables, suppressing every other linter, including default-on linters that are not named.
-  `linter.all` and linter sets are expanded.
-  Switching between {lakeOpt}`--linters` and {lakeOpt}`--lint-only` replaces the prior spec.
+  类似于 {lakeOpt}`--linters`，但仅报告 {lakeMeta}`<spec>` 明确启用的代码检查器，抑制所有其他代码检查器，包括未命名但默认启用的代码检查器。
+  `linter.all` 和代码检查器集合将被展开。
+  在 {lakeOpt}`--linters` 和 {lakeOpt}`--lint-only` 之间切换会替换先前的规范。
 
 : {lakeOptDef flag}`--record-exceptions`
 
-  Record each linter warning as a `set_option <linter> false in` exception by editing the offending source files in place, silencing the warning for that declaration.
-  This implies {lakeOpt}`--builtin-lint`.
+  将每个代码检查器 警告作为 `set_option <linter> false in` 异常记录，通过在原位编辑产生问题的源文件，静默该声明的警告。
+  这隐含了 {lakeOpt}`--builtin-lint`。
 
-A lint driver can be configured by either setting the {tomlField Lake.PackageConfig}`lintDriver` package configuration option or by tagging a script or executable with the {attrs}`@[lint_driver]` attribute.
-A definition in a dependency can be used as a lint driver by using the `<pkg>/<name>` syntax for the {tomlField Lake.PackageConfig}`lintDriver` configuration option.
+可以通过设置包配置选项 {tomlField Lake.PackageConfig}`lintDriver` 或使用 {attrs}`@[lint_driver]` 属性标记脚本或可执行文件来配置 代码检查驱动程序。
+通过将 `<pkg>/<name>` 语法用于 {tomlField Lake.PackageConfig}`lintDriver` 配置选项，可以将依赖项中的定义用作 代码检查驱动程序。
 
-A script lint driver will be run with the package configuration's {tomlField Lake.PackageConfig}`lintDriverArgs` plus the CLI {lakeMeta}`args`.
-An executable lint driver will be built and then run like a script.
+脚本 代码检查驱动程序将结合包配置的 {tomlField Lake.PackageConfig}`lintDriverArgs` 和 CLI {lakeMeta}`args` 运行。
+可执行文件 代码检查驱动程序将被构建，然后如同脚本一样运行。
 :::
 
 ```lakeHelp "check-test"
@@ -977,15 +976,15 @@ package or its dependencies. It merely verifies that one is specified.
 
 :::lake «check-test»
 
-Check if there is a properly configured test driver
+检查是否有正确配置的测试驱动程序
 
-Exits with code 0 if the workspace's root package has a properly
-configured lint driver. Errors (with code 1) otherwise.
+如果工作区的根包具有正确配置的代码检查驱动程序，则以退出码 0 退出。
+否则报错（代码 1）。
 
-Does NOT verify that the configured test driver actually exists in the
-package or its dependencies. It merely verifies that one is specified.
+不验证配置的测试驱动程序是否真正在包或其依赖项中存在。
+它仅仅验证是否指定了一个。
 
-This is useful for distinguishing between failing tests and incorrectly configured packages.
+这对于区分失败的测试和配置不正确的包很有用。
 :::
 
 ```lakeHelp "check-lint"
@@ -1003,19 +1002,19 @@ package or its dependencies. It merely verifies that one is specified.
 ```
 
 :::lake «check-lint»
-Check if there is a properly configured lint driver
+检查是否有正确配置的代码检查驱动程序
 
-Exits with code 0 if the workspace's root package has a properly
-configured lint driver. Errors (with code 1) otherwise.
+如果工作区的根包具有正确配置的代码检查驱动程序，则以退出码 0 退出。
+否则报错（退出代码 1）。
 
-Does NOT verify that the configured lint driver actually exists in the
-package or its dependencies. It merely verifies that one is specified.
+不验证配置的代码检查驱动程序是否真正在包或其依赖项中存在。
+它仅仅验证是否指定了一个。
 
-This is useful for distinguishing between failing lints and incorrectly configured packages.
+这对于区分失败的代码检查和配置不正确的包很有用。
 :::
 
 
-## Scripts
+## 脚本
 
 ```lakeHelp script
 Manage Lake scripts
@@ -1043,7 +1042,7 @@ This command prints the list of all available scripts in the workspace.
 ```
 
 :::lake script list (alias := scripts)
-Lists the available {ref "lake-scripts"}[scripts] in the workspace.
+列出工作区中可用的{ref "lake-scripts"}[脚本]。
 :::
 
 ```lakeHelp run
@@ -1062,19 +1061,19 @@ A bare `lake run` command will run the default script(s) of the root package
 ```
 
 :::lake script run "[[package\"/\"]script [args...]]" (alias := run)
-This command runs the {lakeMeta}`script` of the workspace (or the specified {lakeMeta}`package`),
-passing {lakeMeta}`args` to it.
+此命令运行工作区（或特定 {lakeMeta}`package`）的 {lakeMeta}`script`，
+并将 {lakeMeta}`args` 传递给它。
 
-A bare {lake}`run` command will run the default script(s) of the root package(with no arguments).
+单独的 {lake}`run` 命令将运行根包的默认脚本（没有参数）。
 :::
 
 :::lake script doc "script"
-Prints the documentation comment for {lakeMeta}`script`.
+打印 {lakeMeta}`script` 的文档注释。
 :::
 
 
 
-## Language Server
+## 语言服务器
 
 ```lakeHelp serve
 Start the Lean language server
@@ -1088,12 +1087,12 @@ with the package configuration's `moreServerArgs` field and `args`.
 ```
 
 :::lake serve "[\"--\" args...]"
-Runs the Lean language server in the workspace's root project with the {tech}[package configuration]'s `moreServerArgs` field and {lakeMeta}`args`.
+在工作区的根项目中使用{tech (key := "package configuration")}[包配置]的 `moreServerArgs` 字段和 {lakeMeta}`args` 运行 Lean 语言服务器。
 
-This command is typically invoked by editors or other tooling, rather than manually.
+此命令通常由编辑器或其他工具调用，而不是手动调用。
 :::
 
-# Dependency Management
+# 依赖管理
 
 ```lakeHelp update
 Update dependencies and save them to the manifest
@@ -1117,17 +1116,17 @@ A bare `lake update` will upgrade all dependencies.
 ```
 
 :::lake update "[packages...]"
-Updates the Lake package {tech}[manifest] (i.e., `lake-manifest.json`), downloading and upgrading packages as needed.
-For each new (transitive) {tech}[Git dependency], the appropriate commit is cloned into a subdirectory of the workspace's {tech}[package directory].
-No copy is made of local dependencies.
+更新 Lake 包{tech (key := "manifest")}[清单]（即，`lake-manifest.json`），按需下载和升级包。
+对于每个新的（传递的）{tech (key := "Git dependency")}[Git 依赖]，相应的提交将被克隆到工作区的{tech (key := "package directory")}[包目录]的一个子目录中。
+不对本地依赖项进行复制。
 
-If a set of packages {lakeMeta}`packages` is specified, then these dependencies are upgraded to the latest version compatible with the package's configuration (or removed if removed from the configuration).
-If there are dependencies on multiple versions of the same package, an arbitrary version is selected.
+如果指定了一组包 {lakeMeta}`packages`，那么这些依赖项将被升级到与包配置兼容的最新版本（或者如果从配置中移除，则被删除）。
+如果存在对同一包的多个版本的依赖，则会选择任意一个版本。
 
-A bare {lake}`update` will upgrade all dependencies.
+单独的 {lake}`update` 将升级所有依赖项。
 :::
 
-# Packaging and Distribution
+# 打包和分发
 
 ```lakeHelp "upload"
 Upload build artifacts to a GitHub release
@@ -1140,15 +1139,15 @@ then uploads the asset to the pre-existing GitHub release `tag` using `gh`.
 ```
 
 :::lake upload "tag"
-Packs the root package's `buildDir` into a `tar.gz` archive using `tar` and then uploads the asset to the pre-existing [GitHub](https://github.com) release {lakeMeta}`tag` using [`gh`](https://cli.github.com/).
-Other hosts are not yet supported.
+使用 `tar` 将根包的 `buildDir` 打包为 `tar.gz` 归档文件，然后将该资产上传到已存在的 [GitHub](https://github.com) 发布版 {lakeMeta}`tag`；上传使用 [`gh`](https://cli.github.com/) 完成。
+尚未支持其他主机。
 :::
 
-## Cached Cloud Builds
+## 缓存的云端构建
 
-*These commands are still experimental.*
-They are likely change in future versions of Lake based on user feedback.
-Packages that use Reservoir cloud build archives should enable the {tomlField Lake.PackageConfig}`platformIndependent` setting.
+*这些命令仍然是实验性的。*
+它们可能会在 Lake 的未来版本中根据用户反馈发生变化。
+使用 Reservoir 云构建归档文件的包应启用 {tomlField Lake.PackageConfig}`platformIndependent` 设置。
 
 ```lakeHelp "pack"
 Pack build artifacts into an archive for distribution
@@ -1164,10 +1163,10 @@ Does NOT build any artifacts. It just packs the existing ones.
 ```
 
 :::lake pack "[archive.tar.gz]"
-Packs the root package's {tech}[build directory] into a gzipped tar archive using `tar`.
-If a path for the archive is not specified, the archive in the package's Lake directory (`.lake`) and named according to its `buildArchive` setting.
-This command does not build any artifacts: it only archives what is present.
-Users should ensure that the desired artifacts are present before running this command.
+使用 `tar` 将根包的{tech (key := "build directory")}[构建目录]打包为 gzip tar 归档文件。
+如果未指定归档文件的路径，将在包的 Lake 目录（`.lake`）中并根据其 `buildArchive` 设置命名该归档文件。
+此命令不构建任何工件：它仅将现有的工件进行归档。
+用户在运行此命令之前应确保存在所需的工件。
 :::
 
 ```lakeHelp "unpack"
@@ -1182,21 +1181,21 @@ the package's `buildArchive` in its Lake directory (`.lake`).
 ```
 
 :::lake unpack "[archive.tar.gz]"
-Unpacks the contents of the gzipped tar archive {lakeMeta}`archive.tgz` into the root package's {tech}[build directory].
-If {lakeMeta}`archive.tgz` is not specified, the package's `buildArchive` setting is used to determine a filename, and the file is expected in package's Lake directory (`.lake`).
+将 gzip tar 归档文件 {lakeMeta}`archive.tgz` 的内容解包到根包的{tech (key := "build directory")}[构建目录]中。
+如果未指定 {lakeMeta}`archive.tgz`，将使用包的 `buildArchive` 设置来决定文件名，并预期该文件在包的 Lake 目录（`.lake`）中。
 :::
 
 
-# Local Caches
+# 本地缓存
 
-{lake}`cache get`, {lake}`cache put`, and {lake}`cache add` are used to interact with remote cache servers.
-These commands are *experimental*, and are only useful if the {ref "lake-cache"}[local cache] is enabled.
+{lake}`cache get`、{lake}`cache put` 和 {lake}`cache add` 用于与远程缓存服务器交互。
+这些命令是*实验性的*，并且仅在启用了{ref "lake-cache"}[本地缓存]时有用。
 
-These commands can be configured to use a {deftech}[cache scope], which is a server-specific identifier for a set of build outputs for a package.
-On Reservoir, scopes are currently identical with GitHub repositories, but may include toolchain and platform information in the future.
-Other remote caches may use any scope scheme that they want.
-Cache scopes are specified using the {lakeOptDef option}`--scope=` option.
-Cache scopes are not identical to the scopes used to require packages from Reservoir.
+可以配置这些命令使用{deftech (key := "cache scope")}[缓存作用域]，它是特定于服务器的一个包的一组构建输出的标识符。
+在 Reservoir 上，作用域当前与 GitHub 仓库相同，但将来可能包含工具链和平台信息。
+其他远程缓存可以使用它们想要的任何作用域方案。
+使用 {lakeOptDef option}`--scope=` 选项来指定缓存作用域。
+缓存作用域不同于用于从 Reservoir 请求包的作用域。
 
 ```lakeCacheHelp
 Manage the Lake cache
@@ -1277,32 +1276,32 @@ if any download failed, Lake will exit with a nonzero status code.
 ```
 
 :::lake cache get "[mappings] [\"--max-revs=\" cn] [\"--rev=\" «commit-hash»] [\"--package=\" «name»] [\"--service=\" «name»] [\"--repo=\" «github-repo»] [\"--platform=\" «target-triple»] [\"--toolchain=\"«name»] [\"--scope=\" «remote-scope»] [\"--mappings-only\"] [\"--force-download\"]"
-Downloads build outputs for packages in the workspace from a remote cache service to the local Lake {tech (key:="local cache")}[artifact cache].
-The cache service used can be specified via the {lakeOpt}`--service` option.
-Otherwise, Lake will use the system default, or, if none is configured, Reservoir.
-See {lake}`cache services` for more information on how to configure services.
+从远程缓存服务向本地 Lake {tech (key:="local cache")}[工件缓存]下载工作区中包的构建输出。
+可以通过 {lakeOpt}`--service` 选项指定使用的缓存服务。
+否则，Lake 将使用系统默认服务；如果未配置任何服务，则使用 Reservoir。
+参阅 {lake}`cache services` 了解如何配置服务的更多信息。
 
-By default, Lake will use Reservoir to download outputs for each package in the root's dependency tree in order.
-Non-Reservoir dependencies will be skipped.
-If an input-to-outputs {lakeMeta}`mappings` file, a {lakeMeta}`remote-scope`, or a {lakeMeta}`github-repo` is provided, Lake will instead download build outputs for the root package.
-In either case, {lakeOptDef option}`--package` restricts the download to the outputs of the named package.
+默认情况下，Lake 将使用 Reservoir 按顺序下载根依赖项树中每个包的输出。
+非 Reservoir 依赖将被跳过。
+如果提供了输入到输出 {lakeMeta}`mappings` 文件、{lakeMeta}`remote-scope` 或是 {lakeMeta}`github-repo`，Lake 默认将下载根包的构建输出。
+无论是哪种情况，{lakeOptDef option}`--package` 都会将下载限制在命名的包的输出上。
 
-For Reservoir, setting {lakeOpt}`--repo` will cause Lake to look up outputs for the package by a repository name, rather than the package's.
-This can be used to download outputs for a fork of the Reservoir package (if such artifacts are available).
-The {lakeOpt}`--platform` and {lakeOpt}`--toolchain` options can be used to download artifacts for a different platform/toolchain configuration than Lake detects.
-For a custom endpoint, the full prefix Lake uses can be set via {lakeOpt}`--scope`.
+对于 Reservoir，设置 {lakeOpt}`--repo` 将使 Lake 按仓库名称而不是包名称查找包的输出。
+这可以用来下载 Reservoir 包的一个分支的输出（如果此类工件可用的话）。
+{lakeOpt}`--platform` 和 {lakeOpt}`--toolchain` 选项可用于为 Lake 所检测到的平台/工具链之外的配置下载工件。
+对于自定义端点，Lake 使用的完整前缀可以通过 {lakeOpt}`--scope` 设置。
 
-If `--rev` is not set, Lake uses the package's current revision to look up artifacts.
-Lake will download the artifacts for the most recent commit with available mappings.
-It will backtrack up to {lakeOptDef option}`--max-revs`, which defaults to 100.
-If set to 0, Lake will search the repository's whole history, or as far back as Git will allow.
+如果未设置 `--rev`，Lake 使用包当前的版本来查找工件。
+Lake 将为具有可用映射的最新提交下载工件。
+它最多将回溯 {lakeOptDef option}`--max-revs` 个版本，默认为 100。
+如果设为 0，Lake 将搜索仓库的整个历史记录，或者追溯到 Git 所允许的范围。
 
-By default, Lake will download both the input-to-output mappings and the output artifacts for packages.
-Using {lakeOptDef option}`--mappings-only` will cause Lake to only download the mappings and delay downloading artifacts until they are needed.
-Using {lakeOptDef option}`--force-download` will redownload existing files.
+默认情况下，Lake 将同时下载包的输入到输出映射和输出工件。
+使用 {lakeOptDef option}`--mappings-only` 将使 Lake 仅下载映射，并延迟下载工件，直到它们被需要时为止。
+使用 {lakeOptDef option}`--force-download` 将重新下载现有文件。
 
-While downloading, Lake will continue on when a download for an artifact fails or if the download process for a whole package fails.
-However, it will report this and exit with a nonzero status code in such cases.
+在下载期间，当某工件的下载失败或整个包的下载过程失败时，Lake 将继续执行。
+但是，在这种情况下，它将报告该情况，并以非零状态码退出。
 :::
 
 
@@ -1345,39 +1344,39 @@ has changes.
 ```
 
 ::::lake cache put "mappings [\"--service=\" «name»] [\"--scope=\" «remote-scope»] [\"--repo=\" «github-repo»] [\"--toolchain=\" «name»] [\"--platform=\" «target-triple»]"
-Uploads the input-to-outputs mappings contained in the specified file along with the corresponding output artifacts to a remote cache.
-The cache service used can be specified via the {lakeOpt}`--service` option.
-If not specified, Lake will use the system default, or error if none is configured.
-See {lake}`cache services` for more information on how to configure services.
+将指定文件中包含的输入到输出映射连同相应的输出工件一起上传到远程缓存。
+使用的缓存服务可以通过 {lakeOpt}`--service` 选项指定。
+如果未指定，Lake 将使用系统默认服务；如果未配置，则会报错。
+请参阅 {lake}`cache services` 了解有关如何配置服务的更多信息。
 
-Files are uploaded using the AWS Signature Version 4 authentication protocol via `curl`.
-Thus, the service should generally be an S3-compatible bucket.
-The authentication key is set via the {envVar}`LAKE_CACHE_KEY` environment variable.
+文件是通过 `curl` 使用 AWS Signature Version 4 认证协议上传的。
+因此，该服务通常应是一个兼容 S3 的存储桶。
+认证密钥通过 {envVar}`LAKE_CACHE_KEY` 环境变量设置。
 
-Since Lake does not currently use cryptographically secure hashes for artifacts and outputs, uploads to the cache are prefixed with a scope to avoid clashes.
-The scope is controlled by the following options:
+由于 Lake 目前不对工件和输出使用加密安全的哈希，因此缓存的上传以作用域作为前缀以避免冲突。
+作用域由以下选项控制：
 
 :::table -header
 *
   * {lakeOpt}`--scope`{lit}`=`{lakeMeta}`<remote-scope>`
-  * Uses the provided scope {lakeMeta}`<remote-scope>` verbatim
+  * 原样使用提供的作用域 {lakeMeta}`<remote-scope>`
 *
   * {lakeOptDef option}`--repo`{lit}`=`{lakeMeta}`<github-repo>`
-  * Uses the repository, toolchain, and platform as a scope
+  * 使用仓库、工具链和平台作为作用域
 *
   * {lakeOptDef option}`--toolchain`{lit}`=`{lakeMeta}`<name>`
-  * With {lakeOpt}`--repo`, sets the toolchain
+  * 与 {lakeOpt}`--repo` 一起使用，设置工具链
 *
   * {lakeOptDef option}`--platform`{lit}`=`{lakeMeta}`<target-triple>`
-  * With {lakeOpt}`--repo`, sets the platform
+  * 与 {lakeOpt}`--repo` 一起使用，设置平台
 :::
 
-With {lakeOpt}`--repo`, Lake will produce a scope by augmenting the repository with toolchain and platform information as it deems necessary.
-With {lakeOpt}`--scope`, Lake will use the specified scope verbatim.
+对于 {lakeOpt}`--repo`，Lake 会通过在认为必要时为仓库添加工具链和平台信息来生成作用域。
+对于 {lakeOpt}`--scope`，Lake 会原样使用指定的作用域。
 
-Artifacts are uploaded to the artifact endpoint with a file name derived from their Lake content hash (and prefixed by the repository or scope).
-The mappings file is uploaded to the revision endpoint with a file name derived from the package's current Git revision (and prefixed by the full scope).
-As such, the command will warn if the work tree currently has changes.
+工件会以由其 Lake 内容哈希派生的文件名（带有仓库或作用域前缀）上传到工件端点。
+映射文件会以由该包当前 Git 版本派生的文件名（带有完整作用域前缀）上传到修订版本端点。
+因此，如果工作树目前有更改，命令将会发出警告。
 ::::
 
 ```lakeCacheHelp add
@@ -1411,16 +1410,16 @@ are synonymous.
 ```
 
 ::::lake cache add "mappings [\"--package=\" «name»] [\"--service=\" «name»] [\"--scope=\" «remote-scope»] [\"--repo=\" «github-repo»] [\"--no-overwrite\"]"
-Reads a list of input-to-output mappings from the provided file and adds them to the local Lake cache.
-Mappings already in the cache are overwritten unless {lakeOptDef flag}`--no-overwrite` is specified.
-The mappings are added for the root package unless {lakeOpt}`--package` is specified.
+从提供的文件中读取一系列输入到输出映射，并将它们添加到本地 Lake 缓存中。
+除非指定了 {lakeOptDef flag}`--no-overwrite`，否则缓存中已经存在的映射将被覆盖。
+除非指定了 {lakeOpt}`--package`，否则映射将被添加到根包中。
 
-If {lakeOpt}`--service` is provided, the output artifacts can then be fetched lazily from that service during a Lake build.
-The service must either be `reservoir` or be configured through the Lake system configuration (see {lake}`cache services` for details).
+如果提供了 {lakeOpt}`--service`，那么输出工件可以在 Lake 构建期间从该服务延迟获取。
+服务必须是 `reservoir`，或者是通过 Lake 系统配置进行配置的（请参阅 {lake}`cache services` 了解详情）。
 
-Since Lake does not currently use cryptographically secure hashes for artifacts and outputs, artifacts in a cache service are prefixed with a scope to avoid clashes.
-For Reservoir, this scope can either be a package (set via {lakeOpt}`--scope`) or a repository (set via {lakeOpt}`--repo`).
-For S3 services, both options are synonymous.
+由于 Lake 目前不对工件和输出使用密码安全哈希，因此缓存服务中的工件会添加作用域前缀，以避免冲突。
+对于 Reservoir，该作用域可以是包（通过 {lakeOpt}`--scope` 设置）或仓库（通过 {lakeOpt}`--repo` 设置）。
+对于 S3 服务，这两个选项是同义词。
 ::::
 
 ```lakeCacheHelp clean
@@ -1435,9 +1434,9 @@ delete the default Lake cache directory for the system.
 ```
 
 :::lake cache clean
-Deletes the configured Lake {tech (key:="local cache")}[artifact cache] directory.
-If a workspace configuration exists, this will delete the cache directory it uses.
-Otherwise, it will delete the default Lake cache directory for the system.
+删除配置的 Lake {tech (key:="local cache")}[工件缓存]目录。
+如果工作区配置存在，这将删除其所使用的缓存目录。
+否则，它将删除系统的默认 Lake 缓存目录。
 :::
 
 ```lakeCacheHelp services
@@ -1466,11 +1465,11 @@ If no `cache.defaultService` is configured, Lake will use Reservoir by default.
 ```
 
 ::::lake cache services
-Prints the name of each configured remote cache service (one per line).
-Additional services can be added by modifying the system Lake configuration file, which is usually located at `~/.lake/config.toml` but can be set via the {envVar}`LAKE_CONFIG` environment variable.
+打印每个已配置的远程缓存服务的名称（每行一个）。
+可以通过修改系统 Lake 配置文件添加其他服务，该文件通常位于 `~/.lake/config.toml`，但也可以通过 {envVar}`LAKE_CONFIG` 环境变量进行设置。
 
 :::paragraph
-The configuration of the system cache could look something like the following:
+系统缓存配置类似如下：
 ```toml -link
 cache.defaultService = "my-s3"
 cache.defaultUploadService = "my-s3"
@@ -1481,7 +1480,7 @@ kind = "s3"
 artifactEndpoint = "https://my-s3.com/a0"
 revisionEndpoint = "https://my-s3.com/r0"
 ```
-If no `cache.defaultService` is configured, Lake will use Reservoir by default.
+如果没有配置 `cache.defaultService`，Lake 默认将使用 Reservoir。
 :::
 ::::
 
@@ -1499,11 +1498,10 @@ described cannot be found in the cache.
 ```
 
 ::::lake cache stage "mappings «staging-directory» [\"--force-overwrite\"]"
-Creates {lakeMeta}`staging-directory` and copies the {lakeMeta}`mappings` file to it.
-After this, it copies all artifacts described within the mappings file from the cache to the
-staging directory.
-Artifacts already in the staging directory are not overwritten unless {lakeOptDef flag}`--force-overwrite` is specified.
-It is an error if any of the artifacts described cannot be found in the cache.
+创建 {lakeMeta}`staging-directory` 并将 {lakeMeta}`mappings` 文件复制到其中。
+在这之后，它会将映射文件中描述的所有工件从缓存复制到暂存目录。
+除非指定了 {lakeOptDef flag}`--force-overwrite`，否则已经存在于登台目录中的工件不会被覆盖。
+如果无法在缓存中找到描述的任何工件，则报错。
 ::::
 
 ```lakeCacheHelp unstage
@@ -1524,12 +1522,10 @@ is specified.
 
 ::::lake cache unstage "«staging-directory» [\"--force-overwrite\"]"
 
-Copies the mappings and artifacts stored in {lakeMeta}`staging-directory` (e.g., via {lake}`cache stage`) back into the cache.
+将存储在 {lakeMeta}`staging-directory` 中的映射和工件（例如，通过 {lake}`cache stage` 生成的）复制回缓存中。
 
-Reads the mappings file located at `outputs.jsonl` within the staging
-directory and writes the mappings to the Lake cache. Then, it copies the
-described artifacts from the staging directory into the cache.
-Mappings and artifacts already in the cache are not overwritten unless {lakeOpt}`--force-overwrite` is specified.
+它读取登台目录内的 `outputs.jsonl` 处的映射文件，并将该映射写入 Lake 缓存中。然后，它将描述的工件从登台目录复制到缓存中。
+除非指定了 {lakeOpt}`--force-overwrite`，否则缓存中已经存在的映射和工件不会被覆盖。
 ::::
 
 
@@ -1561,18 +1557,18 @@ specify it with `--rev`.
 ```
 
 ::::lake cache «put-staged» "«staging-directory» [\"--rev=\" «commit-hash»] [\"--service=\" «name»] [\"--scope=\" «remote-scope»] [\"--repo=\" «github-repo»] [\"--toolchain=\" «name»] [\"--platform=\" «target-triple»]"
-Uploads the mappings and artifacts stored in {lakeMeta}`staging-directory` (e.g., via {lake}`cache stage`) to a remote service.
-This works like {lake}`cache put`, except that the outputs are taken from the staging directory rather than from the Lake {tech (key:="local cache")}[artifact cache].
+将存储在 {lakeMeta}`staging-directory` 中的映射和工件（例如，通过 {lake}`cache stage` 生成的）上传到远程服务。
+这与 {lake}`cache put` 工作原理类似，区别在于输出取自暂存目录，而不是来自 Lake {tech (key:="local cache")}[工件缓存]。
 
-This command does not configure the workspace, so it does not execute arbitrary user code.
-As a result, the package's platform and toolchain settings are not detected automatically for {lakeOpt}`--repo`, and they must be specified with {lakeOpt}`--platform` and {lakeOpt}`--toolchain` if they are needed.
+此命令不配置工作区，因此它不执行任意用户代码。
+因此，包的平台和工具链设置对于 {lakeOpt}`--repo` 是无法自动检测到的，如果需要，必须通过 {lakeOpt}`--platform` 和 {lakeOpt}`--toolchain` 指定。
 
-By default, Lake detects the target revision from the workspace directory's current Git revision.
-Outputs can be uploaded for a different revision by specifying it with {lakeOptDef option}`--rev`.
+默认情况下，Lake 将从工作区目录的当前 Git 版本中检测目标版本。
+通过使用 {lakeOptDef option}`--rev` 指定不同的版本，可以上传不同版本的输出。
 ::::
 
 
-# Configuration Files
+# 配置文件
 
 
 ```lakeHelp "translate-config"
@@ -1592,10 +1588,10 @@ non-declarative configuration will be discarded.
 ```
 
 :::lake «translate-config» "lang [«out-file»]"
-Translates the loaded package's configuration into another of Lake's supported configuration languages (i.e., either `lean` or `toml`).
-The produced file is written to `out-file` or, if not provided, the path of the configuration file with the new language's extension.
-If the output file already exists, Lake will error.
+将已加载的包的配置翻译为 Lake 的另一种受支持的配置语言（即 `lean` 或 `toml`）。
+生成的文件将写入 `out-file`，如果未提供，则写入带有新语言扩展名的配置文件路径中。
+如果输出文件已存在，Lake 会报错。
 
-Translation is lossy.
-It does not preserve comments or formatting and non-declarative configuration is discarded.
+翻译是有损的。
+它不会保留注释或格式，非声明性配置将被丢弃。
 :::

--- a/Manual/BuildTools/Lake/CLI.lean
+++ b/Manual/BuildTools/Lake/CLI.lean
@@ -471,7 +471,7 @@ version of the configuration file, respectively. The default is TOML.
 :::
 
 :::TODO
-`lake init` 或 `lake new` 的示例
+此处需补充 `lake init` 或 `lake new` 的示例。
 :::
 
 # 构建与运行
@@ -808,7 +808,7 @@ ANNOTATIONS:
 
 : `--keep-public`
 
-  保留所有的 `public` 导入以保持 API 稳定性
+  保留所有的 `public` 导入以保持接口稳定性
 
 : `--add-public`
 
@@ -999,7 +999,7 @@ package or its dependencies. It merely verifies that one is specified.
 
 检查是否有正确配置的测试驱动程序
 
-如果工作区的根包具有正确配置的代码检查驱动程序，则以退出码 0 退出。
+如果工作区的根包具有正确配置的测试驱动程序，则以退出码 0 退出。
 否则报错（代码 1）。
 
 不验证配置的测试驱动程序是否真正在包或其依赖项中存在。
@@ -1539,7 +1539,7 @@ described cannot be found in the cache.
 ::::lake cache stage "mappings «staging-directory» [\"--force-overwrite\"]"
 创建 {lakeMeta}`staging-directory` 并将 {lakeMeta}`mappings` 文件复制到其中。
 在这之后，它会将映射文件中描述的所有工件从缓存复制到暂存目录。
-除非指定了 {lakeOptDef flag}`--force-overwrite`，否则已经存在于登台目录中的工件不会被覆盖。
+除非指定了 {lakeOptDef flag}`--force-overwrite`，否则已经存在于暂存目录中的工件不会被覆盖。
 如果无法在缓存中找到描述的任何工件，则报错。
 ::::
 
@@ -1563,7 +1563,7 @@ is specified.
 
 将存储在 {lakeMeta}`staging-directory` 中的映射和工件（例如，通过 {lake}`cache stage` 生成的）复制回缓存中。
 
-它读取登台目录内的 `outputs.jsonl` 处的映射文件，并将该映射写入 Lake 缓存中。然后，它将描述的工件从登台目录复制到缓存中。
+它读取暂存目录内的 `outputs.jsonl` 处的映射文件，并将该映射写入 Lake 缓存中。然后，它将描述的工件从暂存目录复制到缓存中。
 除非指定了 {lakeOpt}`--force-overwrite`，否则缓存中已经存在的映射和工件不会被覆盖。
 ::::
 

--- a/Manual/BuildTools/Lake/CLI.lean
+++ b/Manual/BuildTools/Lake/CLI.lean
@@ -262,6 +262,9 @@ fun o =>
 ```
 
 # 选项
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Command-Line-Interface--Options"
+%%%
 
 Lake 的命令行界面提供了许多全局选项以及执行重要任务的子命令。
 单字符标志不能组合；`-HR` 不等于 `-H -R`。
@@ -337,6 +340,9 @@ Lake 的命令行界面提供了许多全局选项以及执行重要任务的子
   尝试下载支持的包的构建缓存
 
 # 控制输出
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Command-Line-Interface--Controlling-Output"
+%%%
 
 这些选项允许控制在构建时生成的{tech (key := "log")}[日志]。
 除了显示或隐藏消息之外，还可以使构建在发出警告甚至信息时失败；这可用于强制实施不允许在构建期间输出的风格指南。
@@ -406,6 +412,9 @@ tag := "automatic-toolchain-updates"
 
 
 # 创建包
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Command-Line-Interface--Creating-Packages"
+%%%
 
 ```lakeHelp "new"
 Create a Lean package in a new directory
@@ -466,6 +475,9 @@ version of the configuration file, respectively. The default is TOML.
 :::
 
 # 构建与运行
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Command-Line-Interface--Building-and-Running"
+%%%
 
 ```lakeHelp "build"
 Build targets
@@ -714,6 +726,9 @@ the workspace's root package's additional Lean arguments and the given args
 :::
 
 # 模块导入
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Command-Line-Interface--Module-Imports"
+%%%
 
 ```lakeHelp shake
 Minimize imports in Lean source files
@@ -815,11 +830,17 @@ ANNOTATIONS:
 ::::
 
 # 开发工具
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Command-Line-Interface--Development-Tools"
+%%%
 
 Lake 包含了对指定标准开发工具和工作流的支持。
 在命令行上，可以使用适当的 `lake` 子命令调用这些工具。
 
 ## 测试和代码检查
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Command-Line-Interface--Development-Tools--Tests-and-Linters"
+%%%
 
 ```lakeHelp test
 Test the workspace's root package using its configured test driver
@@ -1015,6 +1036,9 @@ package or its dependencies. It merely verifies that one is specified.
 
 
 ## 脚本
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Command-Line-Interface--Development-Tools--Scripts"
+%%%
 
 ```lakeHelp script
 Manage Lake scripts
@@ -1074,6 +1098,9 @@ A bare `lake run` command will run the default script(s) of the root package
 
 
 ## 语言服务器
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Command-Line-Interface--Development-Tools--Language-Server"
+%%%
 
 ```lakeHelp serve
 Start the Lean language server
@@ -1093,6 +1120,9 @@ with the package configuration's `moreServerArgs` field and `args`.
 :::
 
 # 依赖管理
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Command-Line-Interface--Dependency-Management"
+%%%
 
 ```lakeHelp update
 Update dependencies and save them to the manifest
@@ -1127,6 +1157,9 @@ A bare `lake update` will upgrade all dependencies.
 :::
 
 # 打包和分发
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Command-Line-Interface--Packaging-and-Distribution"
+%%%
 
 ```lakeHelp "upload"
 Upload build artifacts to a GitHub release
@@ -1144,6 +1177,9 @@ then uploads the asset to the pre-existing GitHub release `tag` using `gh`.
 :::
 
 ## 缓存的云端构建
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Command-Line-Interface--Packaging-and-Distribution--Cached-Cloud-Builds"
+%%%
 
 *这些命令仍然是实验性的。*
 它们可能会在 Lake 的未来版本中根据用户反馈发生变化。
@@ -1187,6 +1223,9 @@ the package's `buildArchive` in its Lake directory (`.lake`).
 
 
 # 本地缓存
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Command-Line-Interface--Local-Caches"
+%%%
 
 {lake}`cache get`、{lake}`cache put` 和 {lake}`cache add` 用于与远程缓存服务器交互。
 这些命令是*实验性的*，并且仅在启用了{ref "lake-cache"}[本地缓存]时有用。
@@ -1569,6 +1608,9 @@ specify it with `--rev`.
 
 
 # 配置文件
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Command-Line-Interface--Configuration-Files"
+%%%
 
 
 ```lakeHelp "translate-config"

--- a/Manual/BuildTools/Lake/Config.lean
+++ b/Manual/BuildTools/Lake/Config.lean
@@ -45,7 +45,7 @@ Lake 为{tech (key := "package configuration")}[包配置]文件提供两种格�
 
   Lean 配置格式更灵活，允许自定义目标、分面和脚本。
   它提供一种嵌入式领域特定语言，用于描述 TOML 格式所提供配置选项的声明式子集。
-  此外，Lake API 还可用于表达声明式选项无法表达的构建配置。
+  此外，Lake 接口 还可用于表达声明式选项无法表达的构建配置。
 
 {lake}`translate-config` 命令可用于在两种格式之间自动转换。
 :::
@@ -1012,7 +1012,7 @@ $[where $_*]?
 tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Lean-Format--Targets--Custom-Targets"
 %%%
 
-可以使用 Lake API，以自定义目标定义任意增量构建的产物。
+可以使用 Lake 接口，以自定义目标定义任意增量构建的产物。
 
 :::syntax command (title := "自定义目标")
 
@@ -1038,7 +1038,7 @@ tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configu
 :::syntax command (title := "自定义包分面")
 
 包分面允许从整个包生成一个或一组产物。
-Lake API 可查询包中的库；因此，包分面的一个常见用途是构建每个库的指定分面。
+Lake 接口 可查询包中的库；因此，包分面的一个常见用途是构建每个库的指定分面。
 
 ```grammar
 $[$_:docComment]?
@@ -1054,7 +1054,7 @@ $[where $_*]?
 :::syntax command (title := "自定义库分面")
 
 库分面允许从库生成一个或一组产物。
-Lake API 可查询库中的模块；因此，库分面的一个常见用途是构建每个模块的指定分面。
+Lake 接口 可查询库中的模块；因此，库分面的一个常见用途是构建每个模块的指定分面。
 
 ```grammar
 $[$_:docComment]?

--- a/Manual/BuildTools/Lake/Config.lean
+++ b/Manual/BuildTools/Lake/Config.lean
@@ -45,7 +45,7 @@ Lake 为{tech (key := "package configuration")}[包配置]文件提供两种格�
 
   Lean 配置格式更灵活，允许自定义目标、分面和脚本。
   它提供一种嵌入式领域特定语言，用于描述 TOML 格式所提供配置选项的声明式子集。
-  此外，Lake 接口 还可用于表达声明式选项无法表达的构建配置。
+  此外，Lake 接口还可用于表达声明式选项无法表达的构建配置。
 
 {lake}`translate-config` 命令可用于在两种格式之间自动转换。
 :::
@@ -1038,7 +1038,7 @@ tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configu
 :::syntax command (title := "自定义包分面")
 
 包分面允许从整个包生成一个或一组产物。
-Lake 接口 可查询包中的库；因此，包分面的一个常见用途是构建每个库的指定分面。
+Lake 接口可查询包中的库；因此，包分面的一个常见用途是构建每个库的指定分面。
 
 ```grammar
 $[$_:docComment]?
@@ -1054,7 +1054,7 @@ $[where $_*]?
 :::syntax command (title := "自定义库分面")
 
 库分面允许从库生成一个或一组产物。
-Lake 接口 可查询库中的模块；因此，库分面的一个常见用途是构建每个模块的指定分面。
+Lake 接口可查询库中的模块；因此，库分面的一个常见用途是构建每个模块的指定分面。
 
 ```grammar
 $[$_:docComment]?

--- a/Manual/BuildTools/Lake/Config.lean
+++ b/Manual/BuildTools/Lake/Config.lean
@@ -13,6 +13,7 @@ import Lake.DSL
 import Manual.Meta
 import Manual.BuildTools.Lake.CLI
 import Manual.ZhDocString.BuildTools.Config
+import Manual.ZhDocString.BuildTools.Lake
 
 
 open Manual
@@ -83,7 +84,7 @@ tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configu
 `lakefile.toml` 的顶层内容指定适用于包本身的选项，包括名称和版本等元数据、{tech (key := "workspace")}[工作区]中文件的位置，以及用于所有{tech (key := "targets")}[目标]的编译器标志等。
 唯一的必填字段是 `name`，它声明包的名称。
 
-:::::tomlTableDocs root "包配置" Lake.PackageConfig (skip := backend) (skip := releaseRepo?) (skip := buildArchive?) (skip := manifestFile) (skip := moreServerArgs) (skip := dynlibs) (skip := plugins)
+:::::tomlTableDocs root "包配置" Lake.PackageConfig (docs := ZhDoc.BuildTools.Config.PackageConfig) (skip := backend) (skip := releaseRepo?) (skip := buildArchive?) (skip := manifestFile) (skip := moreServerArgs) (skip := dynlibs) (skip := plugins)
 
 ::::tomlFieldCategory "元数据" name version versionTags description keywords homepage license licenseFiles readmeFile reservoir
 这些选项描述包。
@@ -397,7 +398,7 @@ tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configu
  * Git 仓库，可以是本地路径或 URL
  * 本地路径
 
-::::tomlTableDocs "require" "引入包" Lake.Dependency (skip := src?) (skip := opts) (skip := subdir) (skip := version)
+::::tomlTableDocs "require" "引入包" Lake.Dependency (docs := ZhDoc.BuildTools.Config.Dependency) (skip := src?) (skip := opts) (skip := subdir) (skip := version)
 
 {tomlField Lake.Dependency}`path` 和 {tomlField Lake.Dependency}`git` 字段为依赖项指定显式来源。
 如果两者均未提供，则从 [Reservoir](https://reservoir.lean-lang.org/) 获取依赖项；如果配置了其他注册表，则从该注册表获取。
@@ -567,7 +568,7 @@ tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configu
 
 库目标应写在 `lean_lib` 表数组中。
 
-::::tomlTableDocs "lean_lib" "库目标" Lake.LeanLibConfig (skip := backend) (skip := globs) (skip := nativeFacets)
+::::tomlTableDocs "lean_lib" "库目标" Lake.LeanLibConfig (docs := ZhDoc.BuildTools.Config.LeanLibConfig) (skip := backend) (skip := globs) (skip := nativeFacets)
 :::tomlField Lake.LeanLibConfig name "库名称" "库名称" String
 库的名称，通常与其唯一模块根同名。
 :::
@@ -668,7 +669,7 @@ precompileModules = true
 tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Declarative-TOML-Format--Executable-Targets"
 %%%
 
-:::: tomlTableDocs "lean_exe" "可执行文件目标" Lake.LeanExeConfig (skip := backend) (skip := globs) (skip := nativeFacets)
+:::: tomlTableDocs "lean_exe" "可执行文件目标" Lake.LeanExeConfig (docs := ZhDoc.BuildTools.Config.LeanExeConfig) (skip := backend) (skip := globs) (skip := nativeFacets)
 :::tomlField Lake.LeanExeConfig name "可执行文件名称" "可执行文件名称" String
 可执行文件的名称。
 :::
@@ -1022,7 +1023,7 @@ target $_:identOrStr $_? : $ty:term := $_:term
 $[where $_*]?
 ```
 
-{zhincludeDocstring Lake.DSL.externLibCommand ZhDoc.BuildTools.Config.DSL.externLibCommand}
+{zhincludeDocstring Lake.DSL.targetCommand ZhDoc.BuildTools.Config.DSL.targetCommand}
 
 :::
 
@@ -1166,7 +1167,7 @@ $[where
 
 :::
 
-{zhdocstring Lake.ScriptM ZhDoc.BuildTools.Config.ScriptM}
+{zhdocstring Lake.ScriptM ZhDoc.BuildTools.Lake.ScriptM}
 
 
 :::syntax attr (label := "属性") (title := "默认脚本")

--- a/Manual/BuildTools/Lake/Config.lean
+++ b/Manual/BuildTools/Lake/Config.lean
@@ -75,6 +75,9 @@ TOML 文件表示将键映射到值的_表_。
 
 
 ## 包配置
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Declarative-TOML-Format--Package-Configuration"
+%%%
 
 `lakefile.toml` 的顶层内容指定适用于包本身的选项，包括名称和版本等元数据、{tech (key := "workspace")}[工作区]中文件的位置，以及用于所有{tech (key := "targets")}[目标]的编译器标志等。
 唯一的必填字段是 `name`，它声明包的名称。
@@ -383,6 +386,9 @@ name = "Sorting"
 :::::
 
 ## 依赖项
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Declarative-TOML-Format--Dependencies"
+%%%
 
 依赖项在包配置的 {toml}`[[require]]` 字段数组中指定，其中同时指定每个包的名称和来源。
 来源有三类：
@@ -554,6 +560,9 @@ source = {type = "git", url = "https://example.com/example.git"}
 :::::
 
 ## 库目标
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Declarative-TOML-Format--Library-Targets"
+%%%
 
 库目标应写在 `lean_lib` 表数组中。
 
@@ -654,6 +663,9 @@ precompileModules = true
 :::::
 
 ## 可执行文件目标
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Declarative-TOML-Format--Executable-Targets"
+%%%
 
 :::: tomlTableDocs "lean_exe" "可执行文件目标" Lake.LeanExeConfig (skip := backend) (skip := globs) (skip := nativeFacets)
 :::tomlField Lake.LeanExeConfig name "可执行文件名称" "可执行文件名称" String
@@ -777,6 +789,9 @@ open Lean (NameMap)
 ```
 
 ## 声明式字段
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Lean-Format--Declarative-Fields"
+%%%
 
 Lean 配置格式的声明式子集使用声明字段序列来指定配置选项。
 
@@ -790,6 +805,9 @@ $_ := $_
 :::
 
 ## 包
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Lean-Format--Packages"
+%%%
 ::::syntax command (title := "包配置")
 ```grammar
 $[$_:docComment]?
@@ -830,6 +848,9 @@ post_update $[$name]? $v
 
 
 ## 依赖项
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Lean-Format--Dependencies"
+%%%
 
 依赖项使用 {keywordOf Lake.DSL.requireDecl}`require` 声明指定。
 
@@ -865,6 +886,9 @@ from git $t $[@ $t]? $[/ $t]?
 
 
 ## 目标
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Lean-Format--Targets"
+%%%
 
 
 
@@ -882,6 +906,9 @@ default_target
 :::
 
 ### 库
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Lean-Format--Targets--Libraries"
+%%%
 
 
 :::syntax command (title := "库目标")
@@ -920,6 +947,9 @@ $[where
 {docstring Lake.LeanLibConfig}
 
 ### 可执行文件
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Lean-Format--Targets--Executables"
+%%%
 
 :::syntax command (title := "可执行文件目标")
 
@@ -953,6 +983,9 @@ $[where
 {docstring Lake.LeanExeConfig}
 
 ### 外部库
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Lean-Format--Targets--External-Libraries"
+%%%
 
 由于外部库可以用任意语言编写并需要任意构建步骤，它们被定义为在 {name Lake.FetchM}`FetchM` 单子中编写、生成 {name Lake.Job}`Job` 的程序。
 外部库目标应生成一个执行构建并返回所得静态库位置的构建作业。
@@ -973,6 +1006,9 @@ $[where $_*]?
 :::
 
 ### 自定义目标
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Lean-Format--Targets--Custom-Targets"
+%%%
 
 可以使用 Lake API，以自定义目标定义任意增量构建的产物。
 
@@ -990,6 +1026,9 @@ $[where $_*]?
 :::
 
 ### 自定义分面
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Lean-Format--Targets--Custom-Facets"
+%%%
 
 自定义分面允许从模块、库或包增量构建额外产物。
 
@@ -1042,6 +1081,9 @@ $[where $_*]?
 :::
 
 ## 配置值类型
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Lean-Format--Configuration-Value-Types"
+%%%
 
 {docstring Lake.BuildType}
 
@@ -1095,6 +1137,9 @@ $_:name".+"
 {docstring Lake.Backend}
 
 ## 脚本
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Lean-Format--Scripts"
+%%%
 
 Lake 脚本用于自动化需要访问包配置、但不参与从代码增量构建产物的任务。
 脚本在 {name Lake.ScriptM}`ScriptM` 单子中运行；它是在 {name}`IO` 上叠加一个提供包配置访问能力的{tech (key := "reader monad")}[读取器单子]{tech (key := "monad transformer")}[变换器]。
@@ -1135,6 +1180,9 @@ default_script
 
 
 ## 实用工具
+%%%
+tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Lean-Format--Utilities"
+%%%
 
 :::syntax term (title := "当前目录")
 ```grammar

--- a/Manual/BuildTools/Lake/Config.lean
+++ b/Manual/BuildTools/Lake/Config.lean
@@ -12,6 +12,7 @@ import Lake.DSL
 
 import Manual.Meta
 import Manual.BuildTools.Lake.CLI
+import Manual.ZhDocString.BuildTools.Config
 
 
 open Manual
@@ -124,7 +125,7 @@ tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configu
 
 :::tomlField Lake.PackageConfig defaultTargets "默认目标名称（数组）" "默认目标名称（数组）" String (sort := 2)
 
-{includeDocstring Lake.Package.defaultTargets -elab}
+{zhincludeDocstring Lake.Package.defaultTargets ZhDoc.BuildTools.Config.Package.defaultTargets}
 
 :::
 
@@ -429,7 +430,7 @@ Git 仓库中的依赖项，可以用 URL 字符串指定，也可以用包含�
 
 :::tomlField Lake.Dependency version "字符串形式的版本" "字符串形式的版本" String
 
-{includeDocstring Lake.Dependency.version}
+{zhincludeDocstring Lake.Dependency.version ZhDoc.BuildTools.Config.Dependency.version}
 
 :::
 
@@ -797,7 +798,7 @@ Lean 配置格式的声明式子集使用声明字段序列来指定配置选项
 
 :::syntax Lake.DSL.declField (title := "声明式字段") -open
 
-{includeDocstring Lake.DSL.declField}
+{zhincludeDocstring Lake.DSL.declField ZhDoc.BuildTools.Config.DSL.declField}
 
 ```grammar
 $_ := $_
@@ -842,7 +843,7 @@ $[where
 post_update $[$name]? $v
 ```
 
-{includeDocstring Lake.DSL.postUpdateDecl}
+{zhincludeDocstring Lake.DSL.postUpdateDecl ZhDoc.BuildTools.Config.DSL.postUpdateDecl}
 
 ::::
 
@@ -872,7 +873,7 @@ Git 修订版本可以是分支名、标签名或提交哈希。
 
 :::syntax fromClause -open (title := "包来源")
 
-{includeDocstring Lake.DSL.fromClause}
+{zhincludeDocstring Lake.DSL.fromClause ZhDoc.BuildTools.Config.DSL.fromClause}
 
 ```grammar
 from $t:term
@@ -944,7 +945,7 @@ $[where
 
 {keywordOf Lake.DSL.leanLibCommand}`lean_lib` 的字段就是 {name Lake.LeanLibConfig}`LeanLibConfig` 结构的字段。
 
-{docstring Lake.LeanLibConfig}
+{zhdocstring Lake.LeanLibConfig ZhDoc.BuildTools.Config.LeanLibConfig}
 
 ### 可执行文件
 %%%
@@ -980,7 +981,7 @@ $[where
 
 {keywordOf Lake.DSL.leanExeCommand}`lean_exe` 的字段就是 {name Lake.LeanExeConfig}`LeanExeConfig` 结构的字段。
 
-{docstring Lake.LeanExeConfig}
+{zhdocstring Lake.LeanExeConfig ZhDoc.BuildTools.Config.LeanExeConfig}
 
 ### 外部库
 %%%
@@ -1001,7 +1002,7 @@ extern_lib $_:identOrStr $_? := $_:term
 $[where $_*]?
 ```
 
-{includeDocstring Lake.DSL.externLibCommand}
+{zhincludeDocstring Lake.DSL.externLibCommand ZhDoc.BuildTools.Config.DSL.externLibCommand}
 
 :::
 
@@ -1021,7 +1022,7 @@ target $_:identOrStr $_? : $ty:term := $_:term
 $[where $_*]?
 ```
 
-{includeDocstring Lake.DSL.externLibCommand}
+{zhincludeDocstring Lake.DSL.externLibCommand ZhDoc.BuildTools.Config.DSL.externLibCommand}
 
 :::
 
@@ -1045,7 +1046,7 @@ package_facet $_:identOrStr $_? : $ty:term := $_:term
 $[where $_*]?
 ```
 
-{includeDocstring Lake.DSL.packageFacetDecl}
+{zhincludeDocstring Lake.DSL.packageFacetDecl ZhDoc.BuildTools.Config.DSL.packageFacetDecl}
 
 :::
 
@@ -1061,7 +1062,7 @@ library_facet $_:identOrStr $_? : $ty:term := $_:term
 $[where $_*]?
 ```
 
-{includeDocstring Lake.DSL.libraryFacetDecl}
+{zhincludeDocstring Lake.DSL.libraryFacetDecl ZhDoc.BuildTools.Config.DSL.libraryFacetDecl}
 
 :::
 
@@ -1076,7 +1077,7 @@ module_facet $_:identOrStr $_? : $ty:term := $_:term
 $[where $_*]?
 ```
 
-{includeDocstring Lake.DSL.moduleFacetDecl}
+{zhincludeDocstring Lake.DSL.moduleFacetDecl ZhDoc.BuildTools.Config.DSL.moduleFacetDecl}
 
 :::
 
@@ -1085,7 +1086,7 @@ $[where $_*]?
 tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configuration-File-Format--Lean-Format--Configuration-Value-Types"
 %%%
 
-{docstring Lake.BuildType}
+{zhdocstring Lake.BuildType ZhDoc.BuildTools.Config.BuildType}
 
 在 Lake 的 DSL 中，{deftech (key := "globs")}[通配模式]是匹配模块名称集合的模式。
 名称可以强制转换为匹配该名称的通配模式，另有两个后缀运算符用于构造更多通配模式。
@@ -1128,13 +1129,13 @@ $_:name".+"
 
 :::
 
-{docstring Lake.Glob}
+{zhdocstring Lake.Glob ZhDoc.BuildTools.Config.Glob}
 
 
 
-{docstring Lake.LeanOption}
+{zhdocstring Lake.LeanOption ZhDoc.BuildTools.Config.LeanOption}
 
-{docstring Lake.Backend}
+{zhdocstring Lake.Backend ZhDoc.BuildTools.Config.Backend}
 
 ## 脚本
 %%%
@@ -1161,11 +1162,11 @@ $[where
   $_*]?
 ```
 
-{includeDocstring Lake.DSL.scriptDecl}
+{zhincludeDocstring Lake.DSL.scriptDecl ZhDoc.BuildTools.Config.DSL.scriptDecl}
 
 :::
 
-{docstring Lake.ScriptM}
+{zhdocstring Lake.ScriptM ZhDoc.BuildTools.Config.ScriptM}
 
 
 :::syntax attr (label := "属性") (title := "默认脚本")
@@ -1189,7 +1190,7 @@ tag := "The-Lean-Language-Reference--Build-Tools-and-Distribution--Lake--Configu
 __dir__
 ```
 
-{includeDocstring Lake.DSL.dirConst}
+{zhincludeDocstring Lake.DSL.dirConst ZhDoc.BuildTools.Config.DSL.dirConst}
 
 :::
 
@@ -1198,7 +1199,7 @@ __dir__
 get_config? $t
 ```
 
-{includeDocstring Lake.DSL.getConfig}
+{zhincludeDocstring Lake.DSL.getConfig ZhDoc.BuildTools.Config.DSL.getConfig}
 
 :::
 
@@ -1210,7 +1211,7 @@ meta if $_ then
 $[else $_]?
 ```
 
-{includeDocstring Lake.DSL.metaIf}
+{zhincludeDocstring Lake.DSL.metaIf ZhDoc.BuildTools.Config.DSL.metaIf}
 
 :::
 
@@ -1226,7 +1227,7 @@ do
   $[$_:command]*
 ```
 
-{includeDocstring Lake.DSL.cmdDo}
+{zhincludeDocstring Lake.DSL.cmdDo ZhDoc.BuildTools.Config.DSL.cmdDo}
 
 :::
 
@@ -1235,6 +1236,6 @@ do
 run_io $t
 ```
 
-{includeDocstring Lake.DSL.runIO}
+{zhincludeDocstring Lake.DSL.runIO ZhDoc.BuildTools.Config.DSL.runIO}
 
 :::

--- a/Manual/BuildTools/Lake/Config.lean
+++ b/Manual/BuildTools/Lake/Config.lean
@@ -25,101 +25,101 @@ open Lean.Elab.Tactic.GuardMsgs.WhitespaceMode
 
 open Lake.DSL
 
-#doc (Manual) "Configuration File Format" =>
+#doc (Manual) "配置文件格式" =>
 %%%
 tag := "lake-config"
 %%%
 
 :::paragraph
-Lake offers two formats for {tech}[package configuration] files:
+Lake 为{tech (key := "package configuration")}[包配置]文件提供两种格式：
 
 : TOML
 
-  The TOML configuration format is fully declarative.
-  Projects that don't include custom targets, facets, or scripts can use the TOML format.
-  Because TOML parsers are available for a wide variety of languages, using this format facilitates integration with tools that are not written in Lean.
+  TOML 配置格式完全是声明式的。
+  不包含自定义目标、分面或脚本的项目可以使用 TOML 格式。
+  由于许多语言都有 TOML 解析器，使用这种格式便于和不是用 Lean 编写的工具集成。
 
 : Lean
 
-  The Lean configuration format is more flexible and allows for custom targets, facets, and scripts.
-  It features an embedded domain-specific language for describing the declarative subset of configuration options that is available from the TOML format.
-  Additionally, the Lake API can be used to express build configurations that are outside of the possibilities of the declarative options.
+  Lean 配置格式更灵活，允许自定义目标、分面和脚本。
+  它提供一种嵌入式领域特定语言，用于描述 TOML 格式所提供配置选项的声明式子集。
+  此外，Lake API 还可用于表达声明式选项无法表达的构建配置。
 
-The command {lake}`translate-config` can be used to automatically convert between the two formats.
+{lake}`translate-config` 命令可用于在两种格式之间自动转换。
 :::
 
-Both formats are processed similarly by Lake, which extracts the {tech}[package configuration] from the configuration file in the form of internal structure types.
-When the package is {tech (key := "configure package")}[configured], the resulting data structures are written to `lakefile.olean` in the {tech}[build directory].
+Lake 以类似方式处理这两种格式，并以内部结构类型的形式从配置文件提取{tech (key := "package configuration")}[包配置]。
+{tech (key := "configure package")}[配置包]时，所得数据结构会写入{tech (key := "build directory")}[构建目录]中的 `lakefile.olean`。
 
 
-# Declarative TOML Format
+# 声明式 TOML 格式
 %%%
 tag := "lake-config-toml"
 %%%
 
 
-TOML{margin}[[_Tom's Obvious Minimal Language_](https://toml.io/en/) is a standardized format for configuration files.] configuration files describe the most-used, declarative subset of Lake {tech}[package configuration] files.
-TOML files denote _tables_, which map keys to values.
-Values may consist of strings, numbers, arrays of values, or further tables.
-Because TOML allows considerable flexibility in file structure, this reference documents the values that are expected rather than the specific syntax used to produce them.
+TOML{margin}[[_Tom's Obvious Minimal Language_](https://toml.io/en/) 是一种标准化的配置文件格式。] 配置文件描述 Lake {tech (key := "package configuration")}[包配置]文件中最常用的声明式子集。
+TOML 文件表示将键映射到值的_表_。
+值可以是字符串、数字、值数组或嵌套的表。
+由于 TOML 的文件结构非常灵活，本参考手册记录预期的值，而不是生成这些值的具体语法。
 
-The contents of {configFile}`lakefile.toml` should denote a TOML table that describes a Lean package.
-This configuration consists of both scalar fields that describe the entire package, as well as the following fields that contain arrays of further tables:
+{configFile}`lakefile.toml` 的内容应表示描述 Lean 包的 TOML 表。
+该配置既包含描述整个包的标量字段，也包含以下由更多表组成的数组字段：
  * `require`
  * `lean_lib`
  * `lean_exe`
 
-Fields that are not part of the configuration tables described here are presently ignored.
-To reduce the risk of typos, this is likely to change in the future.
-Field names not used by Lake should not be used to store metadata to be processed by other tools.
+目前，不属于此处所述配置表的字段会被忽略。
+为降低拼写错误的风险，这种行为将来可能会改变。
+不应使用 Lake 未使用的字段名来存储供其他工具处理的元数据。
 
 
-## Package Configuration
+## 包配置
 
-The top-level contents of `lakefile.toml` specify the options that apply to the package itself, including metadata such as the name and version, the locations of the files in the {tech}[workspace], compiler flags to be used for all {tech}[targets], and
-The only mandatory field is `name`, which declares the package's name.
+`lakefile.toml` 的顶层内容指定适用于包本身的选项，包括名称和版本等元数据、{tech (key := "workspace")}[工作区]中文件的位置，以及用于所有{tech (key := "targets")}[目标]的编译器标志等。
+唯一的必填字段是 `name`，它声明包的名称。
 
-:::::tomlTableDocs root "Package Configuration" Lake.PackageConfig (skip := backend) (skip := releaseRepo?) (skip := buildArchive?) (skip := manifestFile) (skip := moreServerArgs) (skip := dynlibs) (skip := plugins)
+:::::tomlTableDocs root "包配置" Lake.PackageConfig (skip := backend) (skip := releaseRepo?) (skip := buildArchive?) (skip := manifestFile) (skip := moreServerArgs) (skip := dynlibs) (skip := plugins)
 
-::::tomlFieldCategory "Metadata" name version versionTags description keywords homepage license licenseFiles readmeFile reservoir
-These options describe the package.
-They are used by [Reservoir](https://reservoir.lean-lang.org/) to index and display packages.
-If a field is left out, Reservoir may use information from the package's GitHub repository to fill in details.
+::::tomlFieldCategory "元数据" name version versionTags description keywords homepage license licenseFiles readmeFile reservoir
+这些选项描述包。
+[Reservoir](https://reservoir.lean-lang.org/) 使用它们来索引和显示包。
+如果省略某个字段，Reservoir 可能使用包的 GitHub 仓库信息补全细节。
 
-:::tomlField Lake.PackageConfig name "The package name" "Package names" String
-The package's name.
+:::tomlField Lake.PackageConfig name "包名称" "包名称" String
+包的名称。
 :::
 ::::
 
-:::tomlFieldCategory "Layout" packagesDir srcDir buildDir leanLibDr nativeLibDir binDir irDir
-These options control the top-level directory layout of the package and its build directory.
-Further paths specified by libraries, executables, and targets within the package are relative to these directories.
+:::tomlFieldCategory "布局" packagesDir srcDir buildDir leanLibDr nativeLibDir binDir irDir
+这些选项控制包及其构建目录的顶层目录布局。
+包中库、可执行文件和目标指定的其他路径均相对于这些目录。
 :::
 
-:::tomlFieldCategory "Building and Running" defaultTargets leanLibDir platformIndependent precompileModules moreServerOptions moreGlobalServerArgs buildType leanOptions moreLeanArgs weakLeanArgs moreLeancArgs weakLeancArgs moreLinkArgs weakLinkArgs extraDepTargets
+:::tomlFieldCategory "构建与运行" defaultTargets leanLibDir platformIndependent precompileModules moreServerOptions moreGlobalServerArgs buildType leanOptions moreLeanArgs weakLeanArgs moreLeancArgs weakLeancArgs moreLinkArgs weakLinkArgs extraDepTargets
 
-These options configure how code is built and run in the package.
-Libraries, executables, and other {tech}[targets] within a package can further add to parts of this configuration.
-
-:::
-
-:::tomlFieldCategory "Testing and Linting" testDriver testDriverArgs lintDriver lintDriverArgs builtinLint
-
-The CLI commands {lake}`test` and {lake}`lint` use definitions configured by the {tech}[workspace]'s {tech}[root package] to perform testing and linting.
-The code that is run to perform tests and linting is referred to as the test or lint driver.
-In Lean configuration files, these can be specified by applying the `@[test_driver]` or `@[lint_driver]` attributes to a {tech}[Lake script] or an executable or library target.
-In both Lean and TOML configuration files, they can also be configured by setting these options.
-A target or script `TGT` from a dependency `PKG` can be specified as a test or lint driver using the string `"PKG/TGT"`
+这些选项配置如何在包中构建和运行代码。
+包中的库、可执行文件和其他{tech (key := "targets")}[目标]可以进一步扩充此配置的某些部分。
 
 :::
 
-:::tomlFieldCategory "Cloud Releases" releaseRepo buildArchive preferReleaseBuild
+:::tomlFieldCategory "测试与代码检查" testDriver testDriverArgs lintDriver lintDriverArgs builtinLint
 
-These options define a cloud release for the package, as described in the section on {ref "lake-github"}[GitHub release builds].
+命令行命令 {lake}`test` 和 {lake}`lint` 使用由{tech (key := "workspace")}[工作区]的{tech (key := "root package")}[根包]配置的定义来执行测试和代码检查。
+为执行测试和代码检查而运行的代码称为测试驱动或代码检查驱动。
+在 Lean 配置文件中，可以通过将 `@[test_driver]` 或 `@[lint_driver]` 属性应用于{tech (key := "Lake script")}[Lake 脚本]、可执行文件目标或库目标来指定它们。
+在 Lean 和 TOML 配置文件中，也可以通过设置这些选项来配置它们。
+可以使用字符串 `"PKG/TGT"` 将依赖项 `PKG` 中的目标或脚本 `TGT` 指定为测试或代码检查驱动。
 
 :::
 
-:::tomlField Lake.PackageConfig defaultTargets "default targets' names (array)" "default targets' names (array)" String (sort := 2)
+:::tomlFieldCategory "云端发行版" releaseRepo buildArchive preferReleaseBuild
+
+这些选项为包定义云端发行版，详见{ref "lake-github"}[GitHub 发行版构建]一节。
+
+:::
+
+:::tomlField Lake.PackageConfig defaultTargets "默认目标名称（数组）" "默认目标名称（数组）" String (sort := 2)
 
 {includeDocstring Lake.Package.defaultTargets -elab}
 
@@ -127,9 +127,9 @@ These options define a cloud release for the package, as described in the sectio
 
 :::::
 
-:::::example "Minimal TOML Package Configuration"
-The minimal TOML configuration for a Lean {tech}[package] sets only the package's name, using the default values for all other fields.
-This package contains no {tech}[targets], so there is no code to be built.
+:::::example "最小 TOML 包配置" (file := "Minimal TOML Package Configuration")
+Lean {tech (key := "package")}[包]的最小 TOML 配置只设置包名，其他所有字段均使用默认值。
+此包不含{tech (key := "targets")}[目标]，因此没有需要构建的代码。
 
 ::::lakeToml Lake.PackageConfig _root_
 ```toml
@@ -215,9 +215,9 @@ name = "example-package"
 ::::
 :::::
 
-:::::example "Library TOML Package Configuration"
-The minimal TOML configuration for a Lean {tech}[package] sets the package's name and defines a library target.
-This library is named `Sorting`, and its modules are expected under the `Sorting.*` hierarchy.
+:::::example "库的 TOML 包配置" (file := "Library TOML Package Configuration")
+Lean {tech (key := "package")}[包]的最小 TOML 配置设置包名并定义一个库目标。
+此库名为 `Sorting`，其模块应位于 `Sorting.*` 层次结构下。
 ::::lakeToml Lake.PackageConfig _root_
 ```toml
 name = "example-package"
@@ -382,46 +382,46 @@ name = "Sorting"
 ::::
 :::::
 
-## Dependencies
+## 依赖项
 
-Dependencies are specified in the {toml}`[[require]]` field array of a package configuration, which specifies both the name and the source of each package.
-There are three kinds of sources:
- * [Reservoir](https://reservoir.lean-lang.org/), or an alternative package registry
- * Git repositories, which may be local paths or URLs
- * Local paths
+依赖项在包配置的 {toml}`[[require]]` 字段数组中指定，其中同时指定每个包的名称和来源。
+来源有三类：
+ * [Reservoir](https://reservoir.lean-lang.org/) 或其他包注册表
+ * Git 仓库，可以是本地路径或 URL
+ * 本地路径
 
-::::tomlTableDocs "require" "Requiring Packages" Lake.Dependency (skip := src?) (skip := opts) (skip := subdir) (skip := version)
+::::tomlTableDocs "require" "引入包" Lake.Dependency (skip := src?) (skip := opts) (skip := subdir) (skip := version)
 
-The {tomlField Lake.Dependency}`path` and {tomlField Lake.Dependency}`git` fields specify an explicit source for a dependency.
-If neither are provided, then the dependency is fetched from [Reservoir](https://reservoir.lean-lang.org/), or an alternative registry if one has been configured.
-The {tomlField Lake.Dependency}`scope` field is required when fetching a package from Reservoir.
+{tomlField Lake.Dependency}`path` 和 {tomlField Lake.Dependency}`git` 字段为依赖项指定显式来源。
+如果两者均未提供，则从 [Reservoir](https://reservoir.lean-lang.org/) 获取依赖项；如果配置了其他注册表，则从该注册表获取。
+从 Reservoir 获取包时，必须提供 {tomlField Lake.Dependency}`scope` 字段。
 
-:::tomlField Lake.Dependency path "Path" "Paths" System.FilePath
-A dependency on the local filesystem, specified by its path.
+:::tomlField Lake.Dependency path "路径" "路径" System.FilePath
+本地文件系统中的依赖项，以其路径指定。
 :::
 
-:::tomlField Lake.Dependency git "Git specification" "Git specifications" Lake.DependencySrc
-A dependency in a Git repository, specified either by its URL as a string or by a table with the keys:
- * `url`: the repository URL
- * `subDir`: the subdirectory of the Git repository that contains the package's source code
+:::tomlField Lake.Dependency git "Git 规格" "Git 规格" Lake.DependencySrc
+Git 仓库中的依赖项，可以用 URL 字符串指定，也可以用包含以下键的表指定：
+ * `url`：仓库 URL
+ * `subDir`：Git 仓库中包含包源代码的子目录
 :::
 
-:::tomlField Lake.Dependency rev "Git revision" "Git revisions" String
-For Git or Reservoir dependencies, this field specifies the Git revision, which may be a branch name, a tag name, or a specific hash.
-On Reservoir, the `version` field takes precedence over this field.
+:::tomlField Lake.Dependency rev "Git 修订版本" "Git 修订版本" String
+对于 Git 或 Reservoir 依赖项，此字段指定 Git 修订版本，可以是分支名、标签名或特定哈希。
+在 Reservoir 上，`version` 字段优先于此字段。
 :::
 
-:::tomlField Lake.Dependency source "Package Source" "Package Sources" Lake.DependencySrc
-A dependency source, specified as a self-contained table, which is used when neither the `git` nor the `path` key is present.
-The key `type` should be either the string `"git"` or the string `"path"`.
-If the type is `"path"`, then there must be a further key `"path"` whose value is a string that provides the location of the package on disk.
-If the type is `"git"`, then the following keys should be present:
- * `url`: the repository URL
- * `rev`: the Git revision, which may be a branch name, a tag name, or a specific hash (optional)
- * `subDir`: the subdirectory of the Git repository that contains the package's source code
+:::tomlField Lake.Dependency source "包来源" "包来源" Lake.DependencySrc
+依赖项来源，以独立表指定，在既没有 `git` 键也没有 `path` 键时使用。
+键 `type` 应为字符串 `"git"` 或字符串 `"path"`。
+如果类型是 `"path"`，则还必须有一个 `"path"` 键，其字符串值给出包在磁盘上的位置。
+如果类型是 `"git"`，则应提供以下键：
+ * `url`：仓库 URL
+ * `rev`：Git 修订版本，可以是分支名、标签名或特定哈希（可选）
+ * `subDir`：Git 仓库中包含包源代码的子目录
 :::
 
-:::tomlField Lake.Dependency version "version as string" "versions as strings" String
+:::tomlField Lake.Dependency version "字符串形式的版本" "字符串形式的版本" String
 
 {includeDocstring Lake.Dependency.version}
 
@@ -429,8 +429,8 @@ If the type is `"git"`, then the following keys should be present:
 
 ::::
 
-:::::example "Requiring Packages from Reservoir"
-The package `example` can be required from Reservoir using this TOML configuration:
+:::::example "从 Reservoir 引入包" (file := "Requiring Packages from Reservoir")
+可以使用以下 TOML 配置从 Reservoir 引入包 `example`：
 ::::lakeToml Lake.Dependency require
 ```toml
 [[require]]
@@ -453,8 +453,8 @@ scope = "exampleDev"
 ::::
 :::::
 
-:::::example "Requiring Packages from Git"
-The package `example` can be required from a Git repository using this TOML configuration:
+:::::example "从 Git 引入包" (file := "Requiring Packages from Git")
+可以使用以下 TOML 配置从 Git 仓库引入包 `example`：
 ::::lakeToml Lake.Dependency require
 ```toml
 [[require]]
@@ -477,11 +477,11 @@ version = "≥2.12.0"
 ```
 ::::
 
-In particular, the package will be checked out from the `main` branch, and the version number specified in the package's {tech (key := "package configuration")}[configuration] should be at least `2.12.0`.
+具体而言，该包会从 `main` 分支检出，且包的{tech (key := "package configuration")}[配置]中指定的版本号应不低于 `2.12.0`。
 :::::
 
-:::::example "Requiring Packages from a Git tag"
-The package `example` can be required from the tag `v2.12` in a Git repository using this TOML configuration:
+:::::example "从 Git 标签引入包" (file := "Requiring Packages from a Git tag")
+可以使用以下 TOML 配置从 Git 仓库的 `v2.12` 标签引入包 `example`：
 ::::lakeToml Lake.Dependency require
 ```toml
 [[require]]
@@ -497,11 +497,11 @@ rev = "v2.12"
     opts := {}}]
 ```
 ::::
-The version number specified in the package's {tech (key := "package configuration")}[configuration] is not used.
+不会使用包的{tech (key := "package configuration")}[配置]中指定的版本号。
 :::::
 
-:::::example "Requiring Reservoir Packages from a Git tag"
-The package `example`, found using Reservoir, can be required from the tag `v2.12` in its Git repository using this TOML configuration:
+:::::example "从 Git 标签引入 Reservoir 包" (file := "Requiring Reservoir Packages from a Git tag")
+可以使用以下 TOML 配置，从 Reservoir 找到包 `example`，并从其 Git 仓库的 `v2.12` 标签引入：
 ::::lakeToml Lake.Dependency require
 ```toml
 [[require]]
@@ -513,11 +513,11 @@ scope = "exampleDev"
 #[{name := `example, scope := "exampleDev", version := Lake.InputVer.git "v2.12", src? := none, opts := {}}]
 ```
 ::::
-The version number specified in the package's {tech (key := "package configuration")}[configuration] is not used.
+不会使用包的{tech (key := "package configuration")}[配置]中指定的版本号。
 :::::
 
-:::::example "Requiring Packages from Paths"
-The package `example` can be required from the local path `../example` using this TOML configuration:
+:::::example "从路径引入包" (file := "Requiring Packages from Paths")
+可以使用以下 TOML 配置从本地路径 `../example` 引入包 `example`：
 ::::lakeToml Lake.Dependency require
 ```toml
 [[require]]
@@ -532,11 +532,11 @@ path = "../example"
     opts := {}}]
 ```
 ::::
-Dependencies on local paths are useful when developing multiple packages in a single repository, or when testing whether a change to a dependency fixes a bug in a downstream package.
+在单个仓库中开发多个包，或测试依赖项的某项变更是否修复下游包中的错误时，本地路径依赖项很有用。
 :::::
 
-:::::example "Sources as Tables"
-The information about the package source can be written in an explicit table.
+:::::example "以表表示来源" (file := "Sources as Tables")
+包来源信息可以写在显式表中。
 ::::lakeToml Lake.Dependency require
 ```toml
 [[require]]
@@ -553,19 +553,19 @@ source = {type = "git", url = "https://example.com/example.git"}
 ::::
 :::::
 
-## Library Targets
+## 库目标
 
-Library targets are expected in the `lean_lib` array of tables.
+库目标应写在 `lean_lib` 表数组中。
 
-::::tomlTableDocs "lean_lib" "Library Targets" Lake.LeanLibConfig (skip := backend) (skip := globs) (skip := nativeFacets)
-:::tomlField Lake.LeanLibConfig name "The library name" "Library names" String
-The library's name, which is typically the same as its single module root.
+::::tomlTableDocs "lean_lib" "库目标" Lake.LeanLibConfig (skip := backend) (skip := globs) (skip := nativeFacets)
+:::tomlField Lake.LeanLibConfig name "库名称" "库名称" String
+库的名称，通常与其唯一模块根同名。
 :::
 
 ::::
 
-:::::example "Minimal Library Target"
-This library declaration supplies only a name:
+:::::example "最小库目标" (file := "Minimal Library Target")
+此库声明只提供名称：
 ::::lakeToml Lake.LeanLibConfig lean_lib
 ```toml
 [[lean_lib]]
@@ -604,11 +604,11 @@ name = "TacticTools"
       allowImportAll := false}}]
 ```
 ::::
-The library's source is located in the package's default source directory, in the module hierarchy rooted at `TacticTools`.
+该库的源代码位于包的默认源目录中，处于以 `TacticTools` 为根的模块层次结构下。
 :::::
 
-:::::example "Configured Library Target"
-This library declaration supplies more options:
+:::::example "已配置的库目标" (file := "Configured Library Target")
+此库声明提供更多选项：
 ::::lakeToml Lake.LeanLibConfig lean_lib
 ```toml
 [[lean_lib]]
@@ -649,21 +649,21 @@ precompileModules = true
       allowImportAll := false}}]
 ```
 ::::
-The library's source is located in the directory `src`, in the module hierarchy rooted at `TacticTools`.
-If its modules are accessed at elaboration time, they will be compiled to native code and linked in, rather than run in the interpreter.
+该库的源代码位于 `src` 目录中，处于以 `TacticTools` 为根的模块层次结构下。
+如果在精译时访问其模块，它们会编译为原生代码并链接进来，而不是在解释器中运行。
 :::::
 
-## Executable Targets
+## 可执行文件目标
 
-:::: tomlTableDocs "lean_exe" "Executable Targets" Lake.LeanExeConfig (skip := backend) (skip := globs) (skip := nativeFacets)
-:::tomlField Lake.LeanExeConfig name "The executable's name" "Executable names" String
-The executable's name.
+:::: tomlTableDocs "lean_exe" "可执行文件目标" Lake.LeanExeConfig (skip := backend) (skip := globs) (skip := nativeFacets)
+:::tomlField Lake.LeanExeConfig name "可执行文件名称" "可执行文件名称" String
+可执行文件的名称。
 :::
 
 ::::
 
-:::::example "Minimal Executable Target"
-This executable declaration supplies only a name:
+:::::example "最小可执行文件目标" (file := "Minimal Executable Target")
+此可执行文件声明只提供名称：
 ::::lakeToml Lake.LeanExeConfig lean_exe
 ```toml
 [[lean_exe]]
@@ -703,14 +703,14 @@ name = "trustworthytool"
 def main : List String → IO UInt32 := fun _ => pure 0
 ```
 
-The executable's {lean}`main` function is expected in a module named `trustworthytool.lean` in the package's default source file path.
-The resulting executable is named `trustworthytool`.
+可执行文件的 {lean}`main` 函数应位于包默认源文件路径下名为 `trustworthytool.lean` 的模块中。
+生成的可执行文件名为 `trustworthytool`。
 :::::
 
-:::::example "Configured Executable Target"
-The name `trustworthy-tool` is not a valid Lean name due to the dash (`-`).
-To use this name for an executable target, an explicit module root must be supplied.
-Even though `trustworthy-tool` is a perfectly acceptable name for an executable, the target also specifies that the result of compilation and linking should be named `tt`.
+:::::example "已配置的可执行文件目标" (file := "Configured Executable Target")
+名称 `trustworthy-tool` 因包含连字符（`-`）而不是有效的 Lean 名称。
+要将此名称用于可执行文件目标，必须提供显式模块根。
+尽管 `trustworthy-tool` 完全可以作为可执行文件名，该目标还指定编译和链接的结果应命名为 `tt`。
 
 ::::lakeToml Lake.LeanExeConfig lean_exe
 ```toml
@@ -753,22 +753,22 @@ exeName = "tt"
 def main : List String → IO UInt32 := fun _ => pure 0
 ```
 
-The executable's {lean}`main` function is expected in a module named `TrustworthyTool.lean` in the package's default source file path.
+可执行文件的 {lean}`main` 函数应位于包默认源文件路径下名为 `TrustworthyTool.lean` 的模块中。
 :::::
 
-# Lean Format
+# Lean 格式
 %%%
 tag := "lake-config-lean"
 %%%
 
 
-The Lean format for Lake {tech}[package configuration] files provides a domain-specific language for the declarative features that are supported in the TOML format.
-Additionally, it provides the ability to write Lean code to implement any necessary build logic that is not expressible declaratively.
-The Lean configuration file is named {configFile}`lakefile.lean`.
+Lake {tech (key := "package configuration")}[包配置]文件的 Lean 格式为 TOML 格式支持的声明式功能提供了一种领域特定语言。
+此外，还可以编写 Lean 代码来实现任何无法以声明方式表达的必要构建逻辑。
+Lean 配置文件名为 {configFile}`lakefile.lean`。
 
-Because the Lean format is a Lean source file, it can be edited using all the features of the Lean language server.
-Additionally, Lean's metaprogramming framework allows elaboration-time side effects to be used to implement features such as configuration steps that are conditional on the current platform.
-However, a consequence of the Lean configuration format being a Lean file is that it is not feasible to process such files using tools that are not themselves written in Lean.
+由于 Lean 格式是 Lean 源文件，因此可以使用 Lean 语言服务器的全部功能进行编辑。
+此外，Lean 的元编程框架允许使用精译时副作用，实现依赖当前平台的配置步骤等功能。
+不过，Lean 配置格式是 Lean 文件，这意味着使用并非以 Lean 编写的工具处理此类文件并不可行。
 
 ```lean -show
 section
@@ -776,11 +776,11 @@ open Lake DSL
 open Lean (NameMap)
 ```
 
-## Declarative Fields
+## 声明式字段
 
-The declarative subset of the Lean configuration format uses sequences of declaration fields to specify configuration options.
+Lean 配置格式的声明式子集使用声明字段序列来指定配置选项。
 
-:::syntax Lake.DSL.declField (title := "Declarative Fields") -open
+:::syntax Lake.DSL.declField (title := "声明式字段") -open
 
 {includeDocstring Lake.DSL.declField}
 
@@ -789,8 +789,8 @@ $_ := $_
 ```
 :::
 
-## Packages
-::::syntax command (title := "Package Configuration")
+## 包
+::::syntax command (title := "包配置")
 ```grammar
 $[$_:docComment]?
 $[@[ $_,* ]]?
@@ -814,12 +814,12 @@ $[where
   $[$_:letRecDecl];*]?
 ```
 
-There can only be one {keywordOf Lake.DSL.packageCommand}`package` declaration per Lake configuration file.
-The defined package configuration will be available for reference as `_package`.
+每个 Lake 配置文件只能有一个 {keywordOf Lake.DSL.packageCommand}`package` 声明。
+已定义的包配置可通过 `_package` 引用。
 
 ::::
 
-::::syntax command (title := "Post-Update Hooks")
+::::syntax command (title := "更新后钩子")
 ```grammar
 post_update $[$name]? $v
 ```
@@ -829,27 +829,27 @@ post_update $[$name]? $v
 ::::
 
 
-## Dependencies
+## 依赖项
 
-Dependencies are specified using the {keywordOf Lake.DSL.requireDecl}`require` declaration.
+依赖项使用 {keywordOf Lake.DSL.requireDecl}`require` 声明指定。
 
-:::syntax command (title := "Requiring Packages")
+:::syntax command (title := "引入包")
 ```grammar
 $doc:docComment
 require $name:depName $[@ $[git]? $_:term]? $[$_:fromClause]? $[with $_:term]?
 ```
 
-The `@` clause specifies a package version, which is used when requiring a package from [Reservoir](https://reservoir.lean-lang.org/).
-The version may either be a string that specifies the version declared in the package's {name Lake.PackageConfig.version}`version` field, or a specific Git revision.
-Git revisions may be branch names, tag names, or commit hashes.
+`@` 子句指定包版本，用于从 [Reservoir](https://reservoir.lean-lang.org/) 引入包。
+版本可以是指定包的 {name Lake.PackageConfig.version}`version` 字段中所声明版本的字符串，也可以是具体的 Git 修订版本。
+Git 修订版本可以是分支名、标签名或提交哈希。
 
-The optional {syntaxKind}`fromClause` specifies a package source other than Reservoir, which may be either a Git repository or a local path.
+可选的 {syntaxKind}`fromClause` 指定 Reservoir 以外的包来源，可以是 Git 仓库或本地路径。
 
-The {keywordOf Lake.DSL.requireDecl}`with` clause specifies a {lean}`NameMap String` of Lake options that will be used to configure the dependency.
-This is equivalent to passing {lakeOpt}`-K` options to {lake}`build` when building the dependency on the command line.
+{keywordOf Lake.DSL.requireDecl}`with` 子句指定用于配置依赖项的 Lake 选项 {lean}`NameMap String`。
+这等价于在命令行构建依赖项时向 {lake}`build` 传递 {lakeOpt}`-K` 选项。
 :::
 
-:::syntax fromClause -open (title := "Package Sources")
+:::syntax fromClause -open (title := "包来源")
 
 {includeDocstring Lake.DSL.fromClause}
 
@@ -864,29 +864,29 @@ from git $t $[@ $t]? $[/ $t]?
 :::
 
 
-## Targets
+## 目标
 
 
 
-{tech}[Targets] are typically added to the set of default targets by applying the `default_target` attribute, rather than by explicitly listing them.
+通常通过应用 `default_target` 属性将{tech (key := "Targets")}[目标]加入默认目标集合，而不是显式列出它们。
 :::TODO
-Fix `default_target` above—it's not working on CI, but it is working locally, with the `attr` role.
+修复上面的 `default_target`——它在 CI 上不工作，但在本地配合 `attr` 角色可以工作。
 :::
 
-:::syntax attr (title := "Specifying Default Targets") (label := "attribute") (namespace := Lake.DSL)
+:::syntax attr (title := "指定默认目标") (label := "属性") (namespace := Lake.DSL)
 
 ```grammar
 default_target
 ```
-Marks a target as a default, to be built when no other target is specified.
+将目标标记为默认目标，在未指定其他目标时构建。
 :::
 
-### Libraries
+### 库
 
 
-:::syntax command (title := "Library Targets")
+:::syntax command (title := "库目标")
 
-To define a library in which all configurable fields have their default values, use {keywordOf Lake.DSL.leanLibCommand}`lean_lib` with no further fields.
+要定义所有可配置字段均使用默认值的库，请使用 {keywordOf Lake.DSL.leanLibCommand}`lean_lib`，不再添加字段。
 
 ```grammar
 $[$_:docComment]?
@@ -894,7 +894,7 @@ $[$_:attributes]?
 lean_lib $_:identOrStr
 ```
 
-The default configuration can be modified by providing the new values.
+可以通过提供新值来修改默认配置。
 
 ```grammar
 $[$_:docComment]?
@@ -915,22 +915,22 @@ $[where
 ```
 :::
 
-The fields of {keywordOf Lake.DSL.leanLibCommand}`lean_lib` are those of the {name Lake.LeanLibConfig}`LeanLibConfig` structure.
+{keywordOf Lake.DSL.leanLibCommand}`lean_lib` 的字段就是 {name Lake.LeanLibConfig}`LeanLibConfig` 结构的字段。
 
 {docstring Lake.LeanLibConfig}
 
-### Executables
+### 可执行文件
 
-:::syntax command (title := "Executable Targets")
+:::syntax command (title := "可执行文件目标")
 
-To define an executable in which all configurable fields have their default values, use {keywordOf Lake.DSL.leanExeCommand}`lean_exe` with no further fields.
+要定义所有可配置字段均使用默认值的可执行文件，请使用 {keywordOf Lake.DSL.leanExeCommand}`lean_exe`，不再添加字段。
 
 ```grammar
 $[$_:docComment]? $[$_:attributes]?
 lean_exe $_:identOrStr
 ```
 
-The default configuration can be modified by providing the new values.
+可以通过提供新值来修改默认配置。
 
 ```grammar
 $[$_:docComment]? $[$_:attributes]?
@@ -948,18 +948,18 @@ $[where
 ```
 :::
 
-The fields of {keywordOf Lake.DSL.leanExeCommand}`lean_exe` are those of the {name Lake.LeanExeConfig}`LeanExeConfig` structure.
+{keywordOf Lake.DSL.leanExeCommand}`lean_exe` 的字段就是 {name Lake.LeanExeConfig}`LeanExeConfig` 结构的字段。
 
 {docstring Lake.LeanExeConfig}
 
-### External Libraries
+### 外部库
 
-Because external libraries may be written in any language and require arbitrary build steps, they are defined as programs written in the {name Lake.FetchM}`FetchM` monad that produce a {name Lake.Job}`Job`.
-External library targets should produce a build job that carries out the build and then returns the location of the resulting static library.
-For the external library to link properly when {name Lake.PackageConfig.precompileModules}`precompileModules` is on, the static library produced by an {keyword}`extern_lib` target must follow the platform's naming conventions for libraries (i.e., be named foo.a on Windows or libfoo.a on Unix-like systems).
-The utility function {name}`Lake.nameToStaticLib` converts a library name into its proper file name for current platform.
+由于外部库可以用任意语言编写并需要任意构建步骤，它们被定义为在 {name Lake.FetchM}`FetchM` 单子中编写、生成 {name Lake.Job}`Job` 的程序。
+外部库目标应生成一个执行构建并返回所得静态库位置的构建作业。
+要使外部库在启用 {name Lake.PackageConfig.precompileModules}`precompileModules` 时正确链接，{keyword}`extern_lib` 目标生成的静态库必须遵循平台的库命名约定（即在 Windows 上命名为 foo.a，在类 Unix 系统上命名为 libfoo.a）。
+实用函数 {name}`Lake.nameToStaticLib` 将库名称转换为适合当前平台的文件名。
 
-:::syntax command (title := "External Library Targets")
+:::syntax command (title := "外部库目标")
 
 ```grammar
 $[$_:docComment]?
@@ -972,11 +972,11 @@ $[where $_*]?
 
 :::
 
-### Custom Targets
+### 自定义目标
 
-Custom targets may be used to define any incrementally-built artifact whatsoever, using the Lake API.
+可以使用 Lake API，以自定义目标定义任意增量构建的产物。
 
-:::syntax command (title := "Custom Targets")
+:::syntax command (title := "自定义目标")
 
 ```grammar
 $[$_:docComment]?
@@ -989,15 +989,15 @@ $[where $_*]?
 
 :::
 
-### Custom Facets
+### 自定义分面
 
-Custom facets allow additional artifacts to be incrementally built from a module, library, or package.
+自定义分面允许从模块、库或包增量构建额外产物。
 
 
-:::syntax command (title := "Custom Package Facets")
+:::syntax command (title := "自定义包分面")
 
-Package facets allow the production of an artifact or set of artifacts from a whole package.
-The Lake API makes it possible to query a package for its libraries; thus, one common use for a package facet is to build a given facet of each library.
+包分面允许从整个包生成一个或一组产物。
+Lake API 可查询包中的库；因此，包分面的一个常见用途是构建每个库的指定分面。
 
 ```grammar
 $[$_:docComment]?
@@ -1010,10 +1010,10 @@ $[where $_*]?
 
 :::
 
-:::syntax command (title := "Custom Library Facets")
+:::syntax command (title := "自定义库分面")
 
-Library facets allow the production of an artifact or set of artifacts from a library.
-The Lake API makes it possible to query a library for its modules; thus, one common use for a library facet is to build a given facet of each module.
+库分面允许从库生成一个或一组产物。
+Lake API 可查询库中的模块；因此，库分面的一个常见用途是构建每个模块的指定分面。
 
 ```grammar
 $[$_:docComment]?
@@ -1026,9 +1026,9 @@ $[where $_*]?
 
 :::
 
-:::syntax command (title := "Custom Module Facets")
+:::syntax command (title := "自定义模块分面")
 
-Module facets allow the production of an artifact or set of artifacts from a module, typically by invoking a command-line tool.
+模块分面允许从模块生成一个或一组产物，通常通过调用命令行工具来完成。
 
 ```grammar
 $[$_:docComment]?
@@ -1041,12 +1041,12 @@ $[where $_*]?
 
 :::
 
-## Configuration Value Types
+## 配置值类型
 
 {docstring Lake.BuildType}
 
-In Lake's DSL, {deftech}_globs_ are patterns that match sets of module names.
-There is a coercion from names to globs that match the name in question, and there are two postfix operators for constructing further globs.
+在 Lake 的 DSL 中，{deftech (key := "globs")}[通配模式]是匹配模块名称集合的模式。
+名称可以强制转换为匹配该名称的通配模式，另有两个后缀运算符用于构造更多通配模式。
 
 ```lean -show
 section
@@ -1068,21 +1068,21 @@ open Lake DSL
 
 end
 ```
-:::freeSyntax term (title := "Glob Syntax")
+:::freeSyntax term (title := "通配模式语法")
 
-The glob pattern `N.*` matches `N` or any submodule for which `N` is a prefix.
+通配模式 `N.*` 匹配 `N`，或以 `N` 为前缀的任意子模块。
 
 ```grammar
 $_:name".*"
 ```
 
-The glob pattern `N.+` matches any submodule for which `N` is a strict prefix, but not `N` itself.
+通配模式 `N.+` 匹配严格以 `N` 为前缀的任意子模块，但不匹配 `N` 本身。
 
 ```grammar
 $_:name".+"
 ```
 
-Whitespace is not permitted between the name and `.*` or `.+`.
+名称与 `.*` 或 `.+` 之间不允许有空白。
 
 :::
 
@@ -1094,19 +1094,19 @@ Whitespace is not permitted between the name and `.*` or `.+`.
 
 {docstring Lake.Backend}
 
-## Scripts
+## 脚本
 
-Lake scripts are used to automate tasks that require access to a package configuration but do not participate in incremental builds of artifacts from code.
-Scripts run in the {name Lake.ScriptM}`ScriptM` monad, which is {name}`IO` with an additional {tech}[reader monad] {tech (key := "monad transformer")}[transformer] that provides access to the package configuration.
-In particular, a script should have the type {lean}`List String → ScriptM UInt32`.
-Workspace information in scripts is primarily accessed via the {inst}`MonadWorkspace ScriptM` instance.
+Lake 脚本用于自动化需要访问包配置、但不参与从代码增量构建产物的任务。
+脚本在 {name Lake.ScriptM}`ScriptM` 单子中运行；它是在 {name}`IO` 上叠加一个提供包配置访问能力的{tech (key := "reader monad")}[读取器单子]{tech (key := "monad transformer")}[变换器]。
+具体而言，脚本应具有类型 {lean}`List String → ScriptM UInt32`。
+脚本主要通过 {inst}`MonadWorkspace ScriptM` 实例访问工作区信息。
 
 
 ```lean -show
 example : ScriptFn = (List String → ScriptM UInt32) := rfl
 ```
 
-:::syntax command (title := "Script Declarations")
+:::syntax command (title := "脚本声明")
 ```grammar
 $[$_:docComment]?
 $[@[$_,*]]?
@@ -1123,20 +1123,20 @@ $[where
 {docstring Lake.ScriptM}
 
 
-:::syntax attr (label := "attribute") (title := "Default Scripts")
+:::syntax attr (label := "属性") (title := "默认脚本")
 ```grammar
 default_script
 ```
 
-Marks a {tech}[Lake script] as the {tech}[package]'s default.
+将{tech (key := "Lake script")}[Lake 脚本]标记为{tech (key := "package")}[包]的默认脚本。
 
 :::
 
 
 
-## Utilities
+## 实用工具
 
-:::syntax term (title := "The Current Directory")
+:::syntax term (title := "当前目录")
 ```grammar
 __dir__
 ```
@@ -1145,7 +1145,7 @@ __dir__
 
 :::
 
-:::syntax term (title := "Configuration Options")
+:::syntax term (title := "配置选项")
 ```grammar
 get_config? $t
 ```
@@ -1154,7 +1154,7 @@ get_config? $t
 
 :::
 
-:::syntax command (title := "Compile-Time Conditionals")
+:::syntax command (title := "编译时条件")
 
 ```grammar
 meta if $_ then
@@ -1166,7 +1166,7 @@ $[else $_]?
 
 :::
 
-:::syntax cmdDo (title := "Command Sequences")
+:::syntax cmdDo (title := "命令序列")
 
 ```grammar
   $_:command
@@ -1182,7 +1182,7 @@ do
 
 :::
 
-:::syntax term (title := "Compile-Time Side Effects")
+:::syntax term (title := "编译时副作用")
 ```grammar
 run_io $t
 ```

--- a/Manual/Meta/LakeToml.lean
+++ b/Manual/Meta/LakeToml.lean
@@ -69,22 +69,22 @@ where
 
 
 open Output Html in
-def FieldType.toHtml (plural : Bool := false) : FieldType → Html
-  | .string => if plural then "strings" else "String"
-  | .stringOf x => s!"{x} (as string{if plural then "s" else ""}"
-  | .version => if plural then "version strings" else "Version string"
-  | .path => if plural then "paths" else "Path"
-  | .array t => (if plural then "arrays of " else "Array of ") ++ t.toHtml true
-  | .other _ y none => if plural then y ++ "s" else y
-  | .other _ y (some z) => if plural then z else y
-  | .bool => if plural then "Booleans" else "Boolean"
-  | .target => if plural then "targets" else "target"
-  | .option t => t.toHtml ++ " (optional)"
+def FieldType.toHtml (_plural : Bool := false) : FieldType → Html
+  | .string => "字符串"
+  | .stringOf x => s!"{x}（字符串形式）"
+  | .version => "版本字符串"
+  | .path => "路径"
+  | .array t => "由" ++ t.toHtml true ++ "组成的数组"
+  | .other _ y none => y
+  | .other _ y (some _z) => y
+  | .bool => "布尔值"
+  | .target => "目标"
+  | .option t => t.toHtml ++ "（可选）"
   | .oneOf xs =>
     let opts := xs
       |>.map ({{<code>{{show Html from .text true s!"\"{·}\""}}</code>}})
       |>.intersperse {{", "}}
-    {{"one of " {{opts}} }}
+    {{"以下之一：" {{opts}} }}
 
 structure Field (α) where
   name : Name
@@ -166,7 +166,7 @@ def tomlField : DirectiveExpander
 
 open Verso.Search in
 def tomlTableDomainMapper := {
-  displayName := "Lake TOML Table",
+  displayName := "Lake TOML 表",
   className := "lake-toml-table-domain",
   dataToSearchables := "(domainData) =>
   Object.entries(domainData.contents).map(([key, value]) => {
@@ -183,14 +183,14 @@ def tomlTableDomainMapper := {
 
 open Verso.Search in
 def tomlFieldDomainMapper := {
-  displayName := "Lake TOML Field",
+  displayName := "Lake TOML 字段",
   className := "lake-toml-field-domain",
   dataToSearchables := "(domainData) =>
     Object.entries(domainData.contents).map(([key, value]) => {
       let tableArrayKey = value[0].data.tableArrayKey;
-      let arr = tableArrayKey ? `[[${tableArrayKey}]]` : 'package configuration';
+      let arr = tableArrayKey ? `[[${tableArrayKey}]]` : '包配置';
       return {
-        searchKey: `${value[0].data.field} in ${arr}`,
+        searchKey: `${arr}中的${value[0].data.field}`,
         address: `${value[0].address}#${value[0].id}`,
         domainId: 'Manual.lakeTomlField',
         ref: value,
@@ -237,7 +237,7 @@ def Block.tomlField.descr : BlockDescr where
           <code class="field-name">{{sig}}</code>
         </dt>
         <dd>
-            <p><strong>"Contains:"</strong>" " {{field.type.toHtml}}</p>
+            <p><strong>"包含："</strong>" " {{field.type.toHtml}}</p>
             {{← contents.mapM goB}}
         </dd>
       }}
@@ -412,7 +412,7 @@ dl.toml-table-field-spec {
       let fieldHeader := {{
         <p>
           <strong>
-            {{if categories.isEmpty then "Fields:" else "Other Fields:"}}
+            {{if categories.isEmpty then "字段：" else "其他字段："}}
           </strong>
         </p>
       }}
@@ -433,7 +433,7 @@ dl.toml-table-field-spec {
 
       return {{
         <div class="namedocs" {{idAttr}}>
-          <span class="label">"TOML table"</span>
+          <span class="label">"TOML 表"</span>
           <pre class="signature">{{sig}}</pre>
           <div class="text">
             {{← notFields.mapM goB}}
@@ -511,21 +511,22 @@ private def configKeyMap (n : Name) : MetaM (Std.HashMap Name Name) := do
       m := m.insert info.realName info.name
   return m
 
-def asTable (humanName : String) (n : Name) (skip : List Name := []) : DocElabM Term  := do
+def asTable (humanName : String) (n : Name) (docsName : Name := n)
+    (skip : List Name := []) : DocElabM Term  := do
   let env ← getEnv
   if let some (.inductInfo ii) := env.find? n then
     let allFields := getStructureFieldsFlattened env n (includeSubobjectFields := false) |>.filter (!skip.contains ·)
     let directFields := getStructureFields env n
     -- Sort the direct fields first, because that makes the ordering "more intuitive" in the docs
     let allFields := allFields.filter (directFields.contains ·) ++ allFields.filter (!directFields.contains ·)
-    let ancestry ← getStructureResolutionOrder n
+    let docsAncestry ← getStructureResolutionOrder docsName
     let keyMap ← configKeyMap n
     let tomlFields : Array (Field (Array Term)) ← forallTelescopeReducing ii.type fun params _ =>
       withLocalDeclD `self (mkAppN (mkConst n (ii.levelParams.map mkLevelParam)) params) fun s =>
         allFields.mapM fun fieldName => do
           let proj ← mkProjection s fieldName
           let type ← inferType proj >>= instantiateMVars
-          for struct in ancestry do
+          for struct in docsAncestry do
             if let some projFn := getProjFnInfoForField? env struct fieldName then
               let docs? ← findDocString? env projFn.1
               let docs? ← docs?.mapM fun mdDocs => do
@@ -539,11 +540,11 @@ def asTable (humanName : String) (n : Name) (skip : List Name := []) : DocElabM 
                 else if type.isConstOf ``Name then some .string
                 else if type.isConstOf ``Bool then some .bool
                 else if type.isConstOf ``System.FilePath then some .path
-                else if type.isConstOf ``Lake.WorkspaceConfig then some (.other ``Lake.WorkspaceConfig "Workspace configuration" none)
+                else if type.isConstOf ``Lake.WorkspaceConfig then some (.other ``Lake.WorkspaceConfig "工作区配置" none)
                 else if type.isConstOf ``Lake.BuildType then some (.oneOf buildTypes)
                 else if type.isConstOf ``Lake.StdVer then some .version
-                else if type.isConstOf ``Lake.StrPat then some (.other ``Lake.StrPat "String pattern" none)
-                else if type.isAppOfArity ``Array 1 && (type.getArg! 0).isConstOf ``Lean.LeanOption then some (.array (.other ``Lean.LeanOption "Lean option" none))
+                else if type.isConstOf ``Lake.StrPat then some (.other ``Lake.StrPat "字符串模式" none)
+                else if type.isAppOfArity ``Array 1 && (type.getArg! 0).isConstOf ``Lean.LeanOption then some (.array (.other ``Lean.LeanOption "Lean 选项" none))
                 else if type.isAppOfArity ``Array 1 && (type.getArg! 0).isConstOf ``String then some (.array .string)
                 else if type.isAppOfArity ``Array 1 && (type.getArg! 0).isConstOf ``Name then some (.array .string)
                 else if type.isAppOfArity ``Array 1 && (type.getArg! 0).isConstOf ``System.FilePath then some (.array .path)
@@ -552,7 +553,7 @@ def asTable (humanName : String) (n : Name) (skip : List Name := []) : DocElabM 
                 else if type.isAppOfArity ``Option 1 && (type.getArg! 0).isConstOf ``String then some (.option .string)
                 else if type.isAppOfArity ``Option 1 && (type.getArg! 0).isConstOf ``System.FilePath then some (.option .path)
                 else if type.isAppOfArity ``Lake.TargetArray 1 && (type.getArg! 0).isConstOf ``Lake.Dynlib then
-                  some (.array (.other ``Lake.Dynlib "dynamic library" "dynamic libraries"))
+                  some (.array (.other ``Lake.Dynlib "动态库" "动态库"))
                 else if type.isAppOfArity ``Lake.TargetArray 1 && (type.getArg! 0).isConstOf ``System.FilePath then
                   some (.array .path)
                 else none
@@ -586,10 +587,14 @@ structure TomlTableOpts where
   arrayKey : Option String
   description : String
   name : Name
+  /-- Optional shape-compatible structure from which translated documentation is read. -/
+  docs : Option Name
   skip : List Name
 
 def TomlTableOpts.parse [Monad m] [MonadError m] [MonadLiftT CoreM m] : ArgParse m TomlTableOpts :=
-  TomlTableOpts.mk <$> .positional `key arrayKey <*> .positional `description .string <*> .positional `name .resolvedName <*> many (.named `skip .name false)
+  TomlTableOpts.mk <$> .positional `key arrayKey <*> .positional `description .string <*>
+    .positional `name .resolvedName <*> .named `docs .resolvedName true <*>
+    many (.named `skip .name false)
 where
   arrayKey := {
     description := "'root' for the root table, or a string that contains a key for nested tables",
@@ -610,10 +615,11 @@ Interpret a structure type as a TOML table, and generate docs.
 @[directive_expander tomlTableDocs]
 def tomlTableDocs : DirectiveExpander
   | args, contents => do
-    let {arrayKey, description, name, skip} ← TomlTableOpts.parse.run args
+    let {arrayKey, description, name, docs, skip} ← TomlTableOpts.parse.run args
+    let docsName := docs.getD name
     let docsStx ←
-      match ← Lean.findDocString? (← getEnv) name with
-      | none => throwError m!"No docs found for '{name}'"; pure #[]
+      match ← Lean.findDocString? (← getEnv) docsName with
+      | none => throwError m!"No docs found for '{docsName}'"; pure #[]
       | some docs =>
         let some ast := MD4Lean.parse docs
           | throwError "Failed to parse docstring as Markdown"
@@ -623,7 +629,7 @@ def tomlTableDocs : DirectiveExpander
         -- TODO: detect and add xref to `lake` subcommands or other fields here.
         ast.blocks.mapM (blockFromMarkdown (handleHeaders := strongEmphHeaders))
 
-    let tableStx ← Toml.asTable description name skip
+    let tableStx ← Toml.asTable description name docsName skip
 
     let userContents ← contents.mapM elabBlock
 

--- a/Manual/ZhDocString.lean
+++ b/Manual/ZhDocString.lean
@@ -12,3 +12,5 @@ import Manual.ZhDocString.Monads.State
 import Manual.ZhDocString.NotationsMacros.Core
 import Manual.ZhDocString.NotationsMacros.Do
 import Manual.ZhDocString.NotationsMacros.Syntax
+import Manual.ZhDocString.BuildTools.Lake
+import Manual.ZhDocString.BuildTools.Config

--- a/Manual/ZhDocString/BuildTools/Config.lean
+++ b/Manual/ZhDocString/BuildTools/Config.lean
@@ -1,0 +1,531 @@
+/-
+Copyright (c) 2026 Lean 中文社区. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Lean 中文社区
+-/
+import Lake.Config.Monad
+import Lake.DSL
+import Manual.ZhDocString.ZhDocString
+
+open Lean System
+
+namespace ZhDoc.BuildTools.Config
+
+/--
+模块构建目标所共有的配置选项。
+-/
+structure LeanConfig where
+  /--
+  构建模块所采用的模式（例如 `debug`、`release`）。
+  默认为 `release`。
+  -/
+  buildType : _root_.Lake.BuildType := .release
+  /--
+  传给由 `lake serve` 启动的 Lean 语言服务器（即 `lean --server`）以及编译模块 Lean
+  源文件时所用 `lean` 的额外选项 `Array`。
+  -/
+  leanOptions : Array _root_.Lean.LeanOption := #[]
+  /--
+  编译模块的 Lean 源文件时传给 `lean` 的额外实参。
+  -/
+  moreLeanArgs : Array String := #[]
+  /--
+  编译模块的 Lean 源文件时传给 `lean` 的额外实参。
+
+  与 `moreLeanArgs` 不同，这些实参不影响构建结果的跟踪，因此改变它们不会触发重新构建。
+  它们位于 `moreLeanArgs` **之前**。
+  -/
+  weakLeanArgs : Array String := #[]
+  /--
+  编译由 `lean` 从模块 C 源文件生成的内容时，传给 `leanc` 的额外实参。
+
+  Lake 已根据 `buildType` 传入一些标志，但可以通过添加 `-O0` 和 `-UNDEBUG` 等方式改变它们。
+  -/
+  moreLeancArgs : Array String := #[]
+  /--
+  传给由 `lake serve` 启动的 Lean 语言服务器（即 `lean --server`）的额外选项。
+  -/
+  moreServerOptions : Array _root_.Lean.LeanOption := #[]
+  /--
+  编译由 `lean` 从模块 C 源文件生成的内容时，传给 `leanc` 的额外实参。
+
+  与 `moreLeancArgs` 不同，这些实参不影响构建结果的跟踪，因此改变它们不会触发重新构建。
+  它们位于 `moreLeancArgs` **之前**。
+  -/
+  weakLeancArgs : Array String := #[]
+  /--
+  链接（静态和共享）时使用的额外目标对象。
+  它们位于原生分面路径**之后**。
+  -/
+  moreLinkObjs : _root_.Lake.TargetArray FilePath := #[]
+  /--
+  链接时传给 `leanc` 的额外目标库（例如用于共享库或二进制可执行文件）。
+  它们位于其他链接对象路径**之后**。
+  -/
+  moreLinkLibs : _root_.Lake.TargetArray _root_.Lake.Dynlib := #[]
+  /--
+  链接时传给 `leanc` 的额外实参（例如用于共享库或二进制可执行文件）。
+  它们位于链接对象路径**之后**。
+  -/
+  moreLinkArgs : Array String := #[]
+  /--
+  链接时传给 `leanc` 的额外实参（例如用于共享库或二进制可执行文件）。
+  它们位于链接对象路径**之后**。
+
+  与 `moreLinkArgs` 不同，这些实参不影响构建结果的跟踪，因此改变它们不会触发重新构建。
+  它们位于 `moreLinkArgs` **之前**。
+  -/
+  weakLinkArgs : Array String := #[]
+  /--
+  构建模块时应使用的编译器后端（例如 `C`、`LLVM`）。
+  默认为 `C`。
+  -/
+  backend : _root_.Lake.Backend := .default
+  /--
+  断言 Lake 是否应假定 Lean 模块与平台无关。
+
+  * 若为 `false`，Lake 会将 `System.Platform.target` 加入代码单元（例如包或库）内的模块跟踪。
+    这会强制 Lean 代码在不同平台上重新精译。
+
+  * 若为 `true`，Lake 会从模块跟踪中排除依赖平台的元素（例如预编译模块、外部库），从而避免在
+    不同平台上重新精译。请注意，这不会影响当前代码单元之外的模块。例如，依赖某个依赖平台库的
+    平台无关包仍然依赖平台。
+
+  * 若为 `none`，Lake 会自然构造跟踪。也就是说，当模块依赖平台相关产物时就将其纳入跟踪，
+    否则不会强制模块依赖平台。
+
+  此处不会检查正确性，因此配置可以作出不实声明而 Lake 不会发现。默认为 `none`。
+  -/
+  platformIndependent : Option Bool := none
+  /--
+  在模块精译期间（通过 `lean --load-dynlib`）加载的动态库目标数组。
+  -/
+  dynlibs : _root_.Lake.TargetArray _root_.Lake.Dynlib := #[]
+  /--
+  在模块精译期间（通过 `lean --plugin`）加载的 Lean 插件目标数组。
+  -/
+  plugins : _root_.Lake.TargetArray _root_.Lake.Dynlib := #[]
+  /--
+  此包或库是否应视为面向模块系统设计。
+
+  启用后，只要某模块导入此代码单元的模块却没有使用模块系统（即没有 `module` 头部），Lake 就会
+  发出警告。这既适用于下游使用者，也适用于同一包中的非模块文件，表明该代码单元的 API 预期采用
+  模块系统的可见性与精译语义。
+
+  导入方可在自己的包或库上设置 `allowNonModules := true` 来选择不接收该警告。
+
+  默认为 `false`。
+  -/
+  requiresModuleSystem : Bool := false
+  /--
+  此包或库是否允许非模块系统文件而不发出警告。
+
+  默认情况下，若此代码单元中的非模块系统文件导入了来自设置了 `requiresModuleSystem` 的代码单元
+  （可能包括其自身）的模块，Lake 会发出警告。将此项设为 `true` 会抑制这些警告，表示该代码单元
+  明知自己混用了非模块系统文件和模块系统依赖。
+
+  默认为 `false`。
+  -/
+  allowNonModules : Bool := false
+
+/-- Lean 库的声明式配置。 -/
+structure LeanLibConfig (name : Name) extends LeanConfig where
+  /--
+  包源目录中包含该库 Lean 源文件的子目录。默认就是上述 `srcDir`。
+
+  （它会作为 `-R` 选项传给 `lean`。）
+  -/
+  srcDir : FilePath := "."
+  /--
+  库的根模块。
+  这些根的子模块（例如 `Lib` 的 `Lib.Foo`）也视为库的一部分。
+  默认值是仅包含目标名称的单个根。
+  -/
+  roots : Array Name := #[name]
+  /--
+  要为库构建的模块 `Glob` 的 `Array`。
+  默认为库的每个 `roots` 各有一个 `Glob.one`。
+
+  子模块通配模式会构建其目录内的每个源文件。
+  通配模式所匹配文件的本地导入（即工作区中的其他模块）也会递归构建。
+  -/
+  globs : Array _root_.Lake.Glob := roots.map _root_.Lake.Glob.one
+  /--
+  库产物的名称。
+  用作其静态和动态二进制文件名的基础。
+  默认为经过名称改编的目标名称。
+  -/
+  libName : String := ""
+  /--
+  在 Windows 上，此库的静态和共享二进制文件是否应带 `lib` 前缀。
+
+  与 Unix 不同，Windows 不要求原生库以 `lib` 开头，且按惯例通常也不这样命名。不过，为了在所有
+  平台上采用一致命名，用户可能希望启用此选项。
+
+  默认为 `false`。
+  -/
+  libPrefixOnWindows : Bool := false
+  /-- 在可执行文件模块之前构建的目标 `Array`。 -/
+  needs : Array _root_.Lake.PartialBuildKey := #[]
+  /--
+  **已弃用。请改用 `needs`。**
+  在库模块之前构建的目标名称 `Array`。
+  -/
+  extraDepTargets : Array Name := #[]
+  /--
+  是否将库的每个模块编译为原生共享库，并在每次导入该模块时加载。这会加速元程序求值，并让
+  解释器能够运行标记为 `@[extern]` 的函数。
+
+  默认为 `false`。
+  -/
+  precompileModules : Bool := false
+  /--
+  对库执行不带其他参数的 `lake build` 时要构建的库分面 `Array`。
+  例如，`#[LeanLib.sharedFacet]` 会构建共享库分面。
+  -/
+  defaultFacets : Array Name := #[_root_.Lake.LeanLib.leanArtsFacet]
+  /--
+  要构建并组合成库的静态库和共享库的模块分面。若 `shouldExport` 为 true，模块分面应导出用户可能
+  希望在库中查找的所有符号。例如，Lean 解释器会使用已链接库中的导出符号。
+
+  默认为单元素的 `Module.oExportFacet`（若 `shouldExport`）或 `Module.oFacet`。也就是从 Lean 源码
+  编译得到的目标文件，其中可能带有导出的 Lean 符号。
+  -/
+  nativeFacets (shouldExport : Bool) : Array (_root_.Lake.ModuleFacet FilePath) :=
+    #[if shouldExport then _root_.Lake.Module.oExportFacet else _root_.Lake.Module.oFacet]
+  /--
+  下游包是否可以 `import all` 此库的模块。
+
+  启用后，下游用户能够访问模块的 `private` 内部实现，包括未标记为 `@[expose]` 的定义体。
+  将来这也可能阻止依赖于 `private` 定义无法从其所在包外部访问这一事实的编译器优化。
+
+  默认为 `false`。
+  -/
+  allowImportAll : Bool := false
+
+/-- Lean 可执行文件的声明式配置。 -/
+structure LeanExeConfig (name : Name) extends LeanConfig where
+  /--
+  包源目录中包含该可执行文件 Lean 源文件的子目录。默认就是上述 `srcDir`。
+
+  （它会作为 `-R` 选项传给 `lean`。）
+  -/
+  srcDir : FilePath := "."
+  /--
+  二进制可执行文件的根模块。
+  应包含一个作为程序入口点的 `main` 定义。
+
+  构建该根时会递归构建其本地导入（即工作区中的其他模块）。
+
+  默认为目标名称。
+  -/
+  root : Name := name
+  /--
+  二进制可执行文件的名称。
+  默认为将目标名称中的每个 `.` 替换为 `-` 后所得的名称。
+  -/
+  exeName : String := name.toStringWithSep "-" (escape := false)
+  /-- 在可执行文件模块之前构建的目标 `Array`。 -/
+  needs : Array _root_.Lake.PartialBuildKey := #[]
+  /--
+  **已弃用。请改用 `needs`。**
+  在可执行文件模块之前构建的目标名称 `Array`。
+  -/
+  extraDepTargets : Array Name := #[]
+  /--
+  通过向 Lean 解释器公开可执行文件中的符号，让该可执行文件能够解释 Lean 文件（例如通过
+  `Lean.Elab.runFrontend`）。
+
+  从实现上说，在 Windows 上会把 Lean 共享库链接到可执行文件；在其他系统上则用 `-rdynamic`
+  链接可执行文件。这会增大 Linux 上的二进制文件，并且在 Windows 上要求 `libInit_shared.dll` 和
+  `libleanshared.dll` 与可执行文件位于同一位置或属于 `PATH`（例如通过 `lake exe`）。因此，只应在
+  必要时启用此功能。
+
+  默认为 `false`。
+  -/
+  supportInterpreter : Bool := false
+  /--
+  要构建并组合成可执行文件的模块分面。
+  若 `shouldExport` 为 true，模块分面应导出用户可能希望在可执行文件中查找的所有符号。例如，
+  Lean 解释器会使用可执行文件中导出的符号。因此，若 `supportInterpreter := true`，
+  `shouldExport` 就会为 `true`。
+
+  默认为单元素的 `Module.oExportFacet`（若 `shouldExport`）或 `Module.oFacet`。也就是从 Lean 源码
+  编译得到的目标文件，其中可能带有导出的 Lean 符号。
+  -/
+  nativeFacets (shouldExport : Bool) : Array (_root_.Lake.ModuleFacet FilePath) :=
+    #[if shouldExport then _root_.Lake.Module.oExportFacet else _root_.Lake.Module.oFacet]
+
+/--
+Lake 中与 CMake 的
+[`CMAKE_BUILD_TYPE`](https://stackoverflow.com/a/59314670) 对应的类型。
+-/
+inductive BuildType
+  /--
+  调试优化、启用断言、启用自定义调试代码，并在可执行文件中包含调试信息（因此可以在调试器中
+  单步执行代码，并将地址转换为源文件:行号）。例如，编译 C 代码时传入 `-O0 -g`。
+  -/
+  | debug
+  /--
+  经过优化，*带*调试信息，但不含调试代码或断言（例如编译 C 代码时传入
+  `-O3 -g -DNDEBUG`）。
+  -/
+  | relWithDebInfo
+  /--
+  与 `release` 相同，但优化目标是大小而非速度（例如编译 C 代码时传入 `-Os -DNDEBUG`）。
+  -/
+  | minSizeRel
+  /--
+  高优化级别，并且不含调试信息、调试代码或断言（例如编译 C 代码时传入 `-O3 -DNDEBUG`）。
+  -/
+  | release
+
+/-- 一组模块名称的规格。 -/
+inductive Glob
+  /-- 仅选择指定的模块名称。 -/
+  | one : Name → Glob
+  /-- 选择指定模块的所有子模块，但不选择模块本身。 -/
+  | submodules : Name → Glob
+  /-- 选择指定模块及其所有子模块。 -/
+  | andSubmodules : Name → Glob
+
+/-- Lean 会像通过 `-D` 传入一样使用的选项。 -/
+structure LeanOption where
+  /-- 选项的名称。 -/
+  name : Name
+  /-- 选项的值。 -/
+  value : _root_.Lean.LeanOptionValue
+
+/--
+用于编译 Lean 的编译器后端。
+-/
+inductive Backend
+  /--
+  强制使用 C 后端。
+  -/
+  | c
+  /--
+  强制使用 LLVM 后端。
+  -/
+  | llvm
+  /--
+  使用默认后端。可由更具体的配置覆盖。
+  -/
+  | default
+
+/--
+`Script` 所用单子的类型。
+
+它是带有 Lake 配置信息的 `IO` 单子。
+-/
+abbrev ScriptM := _root_.Lake.LakeT IO
+
+namespace Package
+
+/--
+默认构建的包目标名称（即对包执行不带其他参数的 `lake build` 时所构建的目标）。
+-/
+def defaultTargets (self : _root_.Lake.Package) : Array Name := self.defaultTargets
+
+end Package
+
+namespace Dependency
+
+/--
+依赖项的目标版本。
+-/
+def version (self : _root_.Lake.Dependency) : _root_.Lake.InputVer := self.version
+
+end Dependency
+
+namespace DSL
+
+open Lean Parser Elab Command
+open _root_.Lake.DSL
+
+/-- 声明式配置中的字段赋值。 -/
+syntax declField := ident " := " term
+
+/--
+为包声明一个执行于 `lake update` 之后的钩子。
+在此包或其下游依赖项之一成功执行 `lake update` 之后运行该单子动作。
+
+**示例**
+
+此功能让 Mathlib 能够在 `lake update` 后同步 Lean 工具链并运行 `cache get`：
+
+```
+lean_exe cache
+post_update pkg do
+  let wsToolchainFile := (← getRootPackage).dir / "lean-toolchain"
+  let mathlibToolchain ← IO.FS.readFile <| pkg.dir / "lean-toolchain"
+  IO.FS.writeFile wsToolchainFile mathlibToolchain
+  let exeFile ← runBuild cache.fetch
+  let exitCode ← env exeFile.toString #["get"]
+  if exitCode ≠ 0 then
+    error s!"{pkg.name}: failed to fetch cache"
+```
+-/
+scoped syntax (name := postUpdateDecl)
+  optional(docComment) optional(Term.attributes)
+  "post_update " (ppSpace simpleBinder)? (declValSimple <|> declValDo)
+: command
+
+syntax fromPath := term
+syntax fromGit := &"git " term:max ("@" term:max)? ("/" term)?
+syntax fromSource := fromGit <|> fromPath
+
+/--
+指定获取包依赖项的具体来源。
+从远程来源下载的依赖项会放入工作区的 `packagesDir`。
+
+**路径依赖项**
+
+```
+from <path>
+```
+
+Lake 会加载相对于依赖方包目录的固定 `path` 所指位置上的包。
+
+**Git 依赖项**
+
+```
+from git <url> [@ <rev>] [/ <subDir>]
+```
+
+Lake 会克隆固定 Git `url` 上可用的 Git 仓库，并检出指定的修订版本 `rev`。修订版本可以是提交
+哈希、分支或标签。若未提供，Lake 默认使用 `master`。检出后，Lake 会加载位于 `subDir` 中的包
+（若没有指定子目录，则加载仓库根目录中的包）。
+-/
+syntax fromClause := " from " fromSource
+
+/--
+定义新的外部库包目标。只有一种形式：
+
+```lean
+extern_lib «target-name» (pkg : NPackage _package.name) :=
+  /- build term of type `FetchM (Job FilePath)` -/
+```
+
+`pkg` 参数（及其类型说明符）可省略。
+其类型为 `NPackage _package.name`，以可证明地表明所提供的包就是定义该目标的包。
+
+该项应构建外部库的**静态**库。
+-/
+scoped syntax (name := externLibCommand)
+  (docComment)? (Term.attributes)? "extern_lib " externLibDeclSpec
+: command
+
+/--
+定义新的包分面。只有一种形式：
+
+```lean
+package_facet «facet-name» (pkg : Package) : α :=
+  /- build term of type `FetchM (Job α)` -/
+```
+
+`pkg` 参数（及其类型说明符）可省略。
+-/
+scoped syntax (name := packageFacetDecl)
+  (docComment)? (Term.attributes)? "package_facet " buildDeclSig
+: command
+
+/--
+定义新的库分面。只有一种形式：
+
+```lean
+library_facet «facet-name» (lib : LeanLib) : α :=
+  /- build term of type `FetchM (Job α)` -/
+```
+
+`lib` 参数（及其类型说明符）可省略。
+-/
+scoped syntax (name := libraryFacetDecl)
+  (docComment)? (Term.attributes)? "library_facet " buildDeclSig
+: command
+
+/--
+定义新的模块分面。只有一种形式：
+
+```lean
+module_facet «facet-name» (mod : Module) : α :=
+  /- build term of type `FetchM (Job α)` -/
+```
+
+`mod` 参数（及其类型说明符）可省略。
+-/
+scoped syntax (name := moduleFacetDecl)
+  (docComment)? (Term.attributes)? "module_facet " buildDeclSig
+: command
+
+/--
+定义新的 Lake 脚本。
+
+**示例**
+
+```
+/-- Display a greeting -/
+script «script-name» (args) do
+  if h : 0 < args.length then
+    IO.println s!"Hello, {args[0]'h}!"
+  else
+    IO.println "Hello, world!"
+  return 0
+```
+-/
+scoped syntax (name := scriptDecl)
+  (docComment)? optional(Term.attributes) "script " scriptDeclSpec
+: command
+
+/--
+在 Lakefile 精译期间展开为包目录路径的宏。
+-/
+scoped syntax (name := dirConst) "__dir__" : term
+
+/--
+在 Lakefile 精译期间展开为指定配置选项的宏；若尚未设置该选项，则展开为 `none`。
+
+配置实参可以通过 Lake 命令行界面（使用 `-K` 选项）设置，也可以通过 `require` 语句中的 `with`
+子句设置。
+-/
+scoped syntax (name := getConfig) "get_config? " ident : term
+
+/--
+`meta if` 命令有两种形式：
+
+```lean
+meta if <c:term> then <a:command>
+meta if <c:term> then <a:command> else <b:command>
+```
+
+若项 `c`（在精译时）求值得到 true，它会展开为命令 `a`。否则，它会展开为命令 `b`（若提供了
+`else` 子句）。
+
+例如，可以使用此命令来指定仅在特定平台上可用的外部库目标：
+
+```lean
+meta if System.Platform.isWindows then
+extern_lib winOnlyLib := ...
+else meta if System.Platform.isOSX then
+extern_lib macOnlyLib := ...
+else meta if System.Platform.isLinux then
+extern_lib linuxOnlyLib := ...
+```
+-/
+scoped syntax (name := metaIf)
+  "meta " "if " term " then " cmdDo (" else " cmdDo)?
+: command
+
+/--
+`do` 命令语法把多个缩进相同的命令组合在一起。
+随后可将这组命令传给通常只接受单个命令的另一条命令（例如 `meta if`）。
+-/
+syntax cmdDo := ("do" many1Indent(command)) <|> command
+
+/--
+在精译时执行一个类型为 `IO α` 的项，并通过 `ToExpr α` 生成对应于所得结果的表达式。
+-/
+scoped syntax:lead (name := runIO) "run_io " doSeq : term
+
+end DSL
+end ZhDoc.BuildTools.Config

--- a/Manual/ZhDocString/BuildTools/Config.lean
+++ b/Manual/ZhDocString/BuildTools/Config.lean
@@ -109,7 +109,7 @@ structure LeanConfig where
   此包或库是否应视为面向模块系统设计。
 
   启用后，只要某模块导入此代码单元的模块却没有使用模块系统（即没有 `module` 头部），Lake 就会
-  发出警告。这既适用于下游使用者，也适用于同一包中的非模块文件，表明该代码单元的 API 预期采用
+  发出警告。这既适用于下游使用者，也适用于同一包中的非模块文件，表明该代码单元的接口预期采用
   模块系统的可见性与精译语义。
 
   导入方可在自己的包或库上设置 `allowNonModules := true` 来选择不接收该警告。
@@ -128,7 +128,7 @@ structure LeanConfig where
   -/
   allowNonModules : Bool := false
 
-/-- 工作区的声明式配置。 -/
+/-- `Workspace` 的声明式配置。 -/
 structure WorkspaceConfig where
   /--
   Lake 下载远程依赖项的目录。
@@ -174,7 +174,7 @@ structure PackageConfig (p : Name) (n : Name) extends WorkspaceConfig, LeanConfi
 
   /--
   Lake 应将包的二进制 Lean 库（例如 `.olean`、`.ilean` 文件）输出到的构建子目录。
-  默认为 `defaultLeanLibDir`（即 `lib`）。
+  默认为 `defaultLeanLibDir`（即 `lib/lean`）。
   -/
   leanLibDir : FilePath := _root_.Lake.defaultLeanLibDir
 
@@ -218,7 +218,7 @@ structure PackageConfig (p : Name) (n : Name) extends WorkspaceConfig, LeanConfi
   请使用语法 `<pkg>/<def>`。
 
   脚本驱动会以 `testDriverArgs` 中配置的实参为先、命令行界面上指定的实参为后（例如通过
-  `lake lint -- <args>...`），由 `lake test` 运行。可执行文件驱动会先构建，再像脚本一样运行。
+  `lake test -- <args>...`），由 `lake test` 运行。可执行文件驱动会先构建，再像脚本一样运行。
   库则只会被构建。
   -/
   testDriver : String := ""
@@ -702,7 +702,7 @@ syntax fromClause := " from " fromSource
 
 ```lean
 extern_lib «target-name» (pkg : NPackage _package.name) :=
-  /- build term of type `FetchM (Job FilePath)` -/
+  /- 构造类型为 `FetchM (Job FilePath)` 的项 -/
 ```
 
 `pkg` 参数（及其类型说明符）可省略。
@@ -719,7 +719,7 @@ scoped syntax (name := externLibCommand)
 
 ```lean
 target «target-name» (pkg : NPackage _package.name) : α :=
-  /- build term of type `FetchM (Job α)` -/
+  /- 构造类型为 `FetchM (Job α)` 的项 -/
 ```
 
 `pkg` 参数（及其类型说明符）可省略。
@@ -734,7 +734,7 @@ scoped syntax (name := targetCommand)
 
 ```lean
 package_facet «facet-name» (pkg : Package) : α :=
-  /- build term of type `FetchM (Job α)` -/
+  /- 构造类型为 `FetchM (Job α)` 的项 -/
 ```
 
 `pkg` 参数（及其类型说明符）可省略。
@@ -748,7 +748,7 @@ scoped syntax (name := packageFacetDecl)
 
 ```lean
 library_facet «facet-name» (lib : LeanLib) : α :=
-  /- build term of type `FetchM (Job α)` -/
+  /- 构造类型为 `FetchM (Job α)` 的项 -/
 ```
 
 `lib` 参数（及其类型说明符）可省略。
@@ -762,7 +762,7 @@ scoped syntax (name := libraryFacetDecl)
 
 ```lean
 module_facet «facet-name» (mod : Module) : α :=
-  /- build term of type `FetchM (Job α)` -/
+  /- 构造类型为 `FetchM (Job α)` 的项 -/
 ```
 
 `mod` 参数（及其类型说明符）可省略。

--- a/Manual/ZhDocString/BuildTools/Config.lean
+++ b/Manual/ZhDocString/BuildTools/Config.lean
@@ -128,6 +128,320 @@ structure LeanConfig where
   -/
   allowNonModules : Bool := false
 
+/-- 工作区的声明式配置。 -/
+structure WorkspaceConfig where
+  /--
+  Lake 下载远程依赖项的目录。
+  默认为 `defaultPackagesDir`（即 `.lake/packages`）。
+  -/
+  packagesDir : FilePath := _root_.Lake.defaultPackagesDir
+
+/-- `Package` 的声明式配置。 -/
+structure PackageConfig (p : Name) (n : Name) extends WorkspaceConfig, LeanConfig where
+  /-- **供内部使用。** 此包是否为 Lean 本身。 -/
+  bootstrap : Bool := false
+
+  /-- 每当使用此包时要构建的目标名称 `Array`。 -/
+  extraDepTargets : Array Name := #[]
+
+  /--
+  是否将包的每个模块编译为原生共享库，并在每次导入该模块时加载。这会加速元程序求值，并让
+  解释器能够运行标记为 `@[extern]` 的函数。
+
+  默认为 `false`。
+  -/
+  precompileModules : Bool := false
+
+  /--
+  传给由 `lake serve` 启动的 Lean 语言服务器（即 `lean --server`）的额外实参；既用于此包，也用于
+  同一会话中从此包浏览的任何包。
+  -/
+  moreGlobalServerArgs : Array String := #[]
+
+  /--
+  包含包的 Lean 源文件的目录。
+  默认为包目录。
+
+  （它会作为 `-R` 选项传给 `lean`。）
+  -/
+  srcDir : FilePath := "."
+
+  /--
+  Lake 应将包的构建结果输出到的目录。
+  默认为 `defaultBuildDir`（即 `.lake/build`）。
+  -/
+  buildDir : FilePath := _root_.Lake.defaultBuildDir
+
+  /--
+  Lake 应将包的二进制 Lean 库（例如 `.olean`、`.ilean` 文件）输出到的构建子目录。
+  默认为 `defaultLeanLibDir`（即 `lib`）。
+  -/
+  leanLibDir : FilePath := _root_.Lake.defaultLeanLibDir
+
+  /--
+  Lake 应将包的原生库（例如 `.a`、`.so`、`.dll` 文件）输出到的构建子目录。
+  默认为 `defaultNativeLibDir`（即 `lib`）。
+  -/
+  nativeLibDir : FilePath := _root_.Lake.defaultNativeLibDir
+
+  /--
+  Lake 应将包的二进制可执行文件输出到的构建子目录。
+  默认为 `defaultBinDir`（即 `bin`）。
+  -/
+  binDir : FilePath := _root_.Lake.defaultBinDir
+
+  /--
+  Lake 应将包的中间结果（例如 `.c` 和 `.o` 文件）输出到的构建子目录。
+  默认为 `defaultIrDir`（即 `ir`）。
+  -/
+  irDir : FilePath := _root_.Lake.defaultIrDir
+
+  /--
+  用于上传和下载此包发行版的 GitHub 仓库 URL。
+  若为 `none`（默认值），下载时 Lake 使用包的下载来源 URL（若它是依赖项），上传时使用 `gh` 的默认值。
+  -/
+  releaseRepo : Option String := none
+
+  /--
+  GitHub 云端发行版构建归档的自定义名称。
+  若为 `none`（默认值），Lake 使用 `{(pkg-)name}-{System.Platform.target}.tar.gz`。
+  -/
+  buildArchive : Option String := none
+
+  /--
+  将此包用作依赖项时，是否优先下载（来自 GitHub 的）预构建发行版，而不是从源代码构建此包。
+  -/
+  preferReleaseBuild : Bool := false
+
+  /--
+  当此包是工作区根时，由 `lake test` 使用的脚本、可执行文件或库的名称。要指向另一包中的定义，
+  请使用语法 `<pkg>/<def>`。
+
+  脚本驱动会以 `testDriverArgs` 中配置的实参为先、命令行界面上指定的实参为后（例如通过
+  `lake lint -- <args>...`），由 `lake test` 运行。可执行文件驱动会先构建，再像脚本一样运行。
+  库则只会被构建。
+  -/
+  testDriver : String := ""
+
+  /--
+  传给包的测试驱动的实参。
+  这些实参位于通过 `lake test -- <args>...` 从命令行传入的实参之前。
+  -/
+  testDriverArgs : Array String := #[]
+
+  /--
+  当此包是工作区根时，由 `lake lint` 使用的脚本或可执行文件的名称。要指向另一包中的定义，
+  请使用语法 `<pkg>/<def>`。
+
+  脚本驱动会以 `lintDriverArgs` 中配置的实参为先、命令行界面上指定的实参为后（例如通过
+  `lake lint -- <args>...`），由 `lake lint` 运行。可执行文件驱动会先构建，再像脚本一样运行。
+  -/
+  lintDriver : String := ""
+
+  /--
+  传给包的代码检查器的实参。
+  这些实参位于通过 `lake lint -- <args>...` 从命令行传入的实参之前。
+  -/
+  lintDriverArgs : Array String := #[]
+
+  /--
+  包版本。版本形式为：
+
+  ```
+  v!"<major>.<minor>.<patch>[-<specialDescr>]"
+  ```
+
+  带有 `-` 后缀的版本视为“预发行版”。
+
+  Lake 建议按以下准则递增版本：
+
+  * **主版本递增**（例如 v1.3.0 → v2.0.0）
+    表示包中有重大的破坏性变更。
+    不应期望包使用者无需手动干预就能更新到新版本。
+
+  * **次版本递增**（例如 v1.3.0 → v1.4.0）
+    表示通常应向后兼容的重要变更。
+    应期望包使用者自动更新到此版本，并能轻松修复任何破坏和/或警告。
+
+  * **补丁版本递增**（例如 v1.3.0 → v1.3.1）
+    保留用于错误修复和小幅润色。
+    应期望包使用者自动更新，且除了使用者依赖已修复错误之行为的边缘情况外，不应出现重大破坏。
+
+  **请注意，任何版本递增都可能发生不向后兼容的变更。**
+  这是因为 Lean 当前的性质（例如传递导入、丰富的元编程、证明中的可约性）使得为包定义完全稳定的
+  接口并不可行。不同版本级别只表示变更预期的重要程度以及预计迁移的难度。
+
+  `0.x.x` 形式的版本视为首次正式发行之前的开发版本。与预发行版一样，它们不必严格遵循上述准则。
+
+  未定义版本的包默认为 `0.0.0`。
+  -/
+  version : _root_.Lake.StdVer := {}
+
+  /--
+  此包仓库中应视为版本的 Git 标签。
+  包索引（例如 Reservoir）可利用此信息确定与已发行版本对应的 Git 修订版本。
+
+  默认为“类似版本”的标签，即以 `v` 开头、后跟数字的标签。
+  -/
+  versionTags : _root_.Lake.StrPat := _root_.Lake.defaultVersionTags
+
+  /-- 包的简短描述（例如供 Reservoir 使用）。 -/
+  description : String := ""
+
+  /--
+  与包关联的自定义关键词。
+  Reservoir 可使用包的关键词对相关包进行分组，让使用者更容易发现它们。
+
+  合适的关键词包括领域（例如 `math`、`software-verification`、`devtool`）、具体子主题（例如
+  `topology`、`cryptology`）和重要实现细节（例如 `dsl`、`ffi`、`cli`）。例如，Lake 的关键词可以是
+  `devtool`、`cli`、`dsl`、`package-manager` 和 `build-system`。
+  -/
+  keywords : Array String := #[]
+
+  /--
+  指向包相关信息的 URL。
+
+  Reservoir 已会包含指向包的 GitHub 仓库的链接（若包来自那里）。因此，建议使用者在此指定其他内容
+  （如果要指定的话）。
+  -/
+  homepage : String := ""
+
+  /--
+  包的许可证（若有）。
+  应为有效的 [SPDX 许可证表达式][1]。
+
+  Reservoir 要求包使用 OSI 批准的许可证才能纳入其索引，目前仅支持单标识符 SPDX 表达式。
+  OSI 批准的 SPDX 许可证标识符列表见 [SPDX 许可证列表][2]。
+
+  [1]: https://spdx.github.io/spdx-spec/v3.0/annexes/SPDX-license-expressions/
+  [2]: https://spdx.org/licenses/
+  -/
+  license : String := ""
+
+  /--
+  包含包许可证信息的文件。
+
+  这些应是使用者分发包源代码时预期附带的许可证文件；某些许可证可能需要多个文件。例如，
+  Apache 2.0 许可证要求在 `NOTICE` 文件存在时，将它与许可证一起复制。
+
+  默认为 `#["LICENSE"]`。
+  -/
+  licenseFiles : Array FilePath := #["LICENSE"]
+
+  /--
+  包的 README 路径。
+
+  README 应为包含包概述的 Markdown 文件。Reservoir 会在包页面上显示该文件渲染后的 HTML。
+  可以使用非标准位置，分别为 Reservoir 和 GitHub 提供不同的 README。
+
+  默认为 `README.md`。
+  -/
+  readmeFile : FilePath := "README.md"
+
+  /--
+  Reservoir 是否应将包纳入其索引。
+  设为 `false` 时，Reservoir 不会将包加入索引；若它已在索引中，则会在 Reservoir 下次更新时移除。
+  -/
+  reservoir : Bool := true
+
+  /--
+  是否为包启用 Lake 的本地离线产物缓存。
+
+  包的产物（即构建产品）会存入与 Lean 工具链关联的缓存，从而在各本地副本间共享。
+  使用大型项目或大型依赖项的多个副本时，这可以显著减少初次构建时间和磁盘占用。
+
+  需要注意的是，支持产物缓存的构建目标不会存储在构建目录中的通常位置。因此，依赖产物特定位置的
+  自定义构建脚本可能需要禁用此功能。
+
+  若为 `none`（默认值），则按顺序回退到：
+  * `LAKE_ARTIFACT_CACHE` 环境变量（若已设置）。
+  * 工作区根的 `enableArtifactCache` 配置（若已设置且此包是依赖项）。
+  * **Lake 的默认值**：包可以使用缓存中的产物，但不能写入缓存。
+  -/
+  enableArtifactCache? : Option Bool := none
+
+  /--
+  启用本地产物缓存后，Lake 是否应将所有缓存产物复制到构建目录。这可确保外部使用者能在构建目录中
+  找到构建结果。
+
+  若为 `none`（默认值），则按顺序回退到：
+  * `LAKE_RESTORE_ARTIFACTS` 环境变量（若已设置）。
+  * 工作区根的 `restoreAllArtifacts` 配置（若已设置且此包是依赖项）。
+  * **Lake 的默认值**：`false`。
+  -/
+  restoreAllArtifacts? : Option Bool := none
+
+  /--
+  此包的原生库在 Windows 上是否应带 `lib` 前缀。
+
+  与 Unix 不同，Windows 不要求原生库以 `lib` 开头，且按惯例通常也不这样命名。不过，为了在所有
+  平台上采用一致命名，使用者可能希望启用此选项。
+
+  默认为 `false`。
+  -/
+  libPrefixOnWindows : Bool := false
+
+  /--
+  下游包是否可以 `import all` 此包的模块。
+
+  启用后，下游使用者能够访问模块的 `private` 内部实现，包括未标记为 `@[expose]` 的定义体。
+  将来这也可能阻止依赖于 `private` 定义无法从其所在包外部访问这一事实的编译器优化。
+
+  默认为 `false`。
+  -/
+  allowImportAll : Bool := false
+
+  /--
+  是否对包运行 Lake 的内置代码检查器。
+
+  * `true` — 始终运行内置代码检查。若还配置了代码检查驱动，则先运行内置代码检查。
+  * `false` — 默认从不运行内置代码检查。若也未配置代码检查驱动，`lake check-lint` 将以非零代码退出。
+  * `none`（默认值）— 当前等同于 `false`。将来的版本中，未配置代码检查驱动时，`none` 会运行内置
+    代码检查（即作为回退时等同于 `true`）。
+  -/
+  builtinLint? : Option Bool := none
+
+  /--
+  此包是否预期仅在单一工具链（包的工具链）上工作。
+
+  这会告知 Lake 的工具链更新过程（在 `lake update` 中）优先采用此包的工具链，也无需在 Lake 缓存中
+  按工具链版本区分此包的输入到输出映射。
+
+  默认为 `false`。
+  -/
+  fixedToolchain : Bool := false
+
+/--
+`Dependency` 表示包的一个依赖项。
+它指定另一个包所依赖的包。
+此结构编码 `require` 领域特定语言语法中包含的信息。
+-/
+structure Dependency where
+  /--
+  依赖项的包名称。
+  此名称必须与其配置文件中声明的名称一致，因为该名称用于索引其目标数据类型。为此，包名称还必须
+  在依赖关系图中的所有包之间唯一。
+  -/
+  name : Name
+  /--
+  用于区分 Lake 注册表中同名包的附加限定符。在 Reservoir 中，这是包所有者。
+  -/
+  scope : String
+  /--
+  依赖项的目标版本。
+  -/
+  version : _root_.Lake.InputVer
+  /--
+  依赖项的来源。
+  若无来源，则在默认注册表（例如 Reservoir）中查找依赖项。
+  支持的来源见 `DependencySrc` 的文档。
+  -/
+  src? : Option _root_.Lake.DependencySrc
+  /--
+  传给依赖项包配置的实参。
+  -/
+  opts : _root_.Lean.NameMap String
+
 /-- Lean 库的声明式配置。 -/
 structure LeanLibConfig (name : Name) extends LeanConfig where
   /--
@@ -165,7 +479,7 @@ structure LeanLibConfig (name : Name) extends LeanConfig where
   默认为 `false`。
   -/
   libPrefixOnWindows : Bool := false
-  /-- 在可执行文件模块之前构建的目标 `Array`。 -/
+  /-- 在库模块之前构建的目标 `Array`。 -/
   needs : Array _root_.Lake.PartialBuildKey := #[]
   /--
   **已弃用。请改用 `needs`。**
@@ -313,13 +627,6 @@ inductive Backend
   -/
   | default
 
-/--
-`Script` 所用单子的类型。
-
-它是带有 Lake 配置信息的 `IO` 单子。
--/
-abbrev ScriptM := _root_.Lake.LakeT IO
-
 namespace Package
 
 /--
@@ -328,15 +635,6 @@ namespace Package
 def defaultTargets (self : _root_.Lake.Package) : Array Name := self.defaultTargets
 
 end Package
-
-namespace Dependency
-
-/--
-依赖项的目标版本。
--/
-def version (self : _root_.Lake.Dependency) : _root_.Lake.InputVer := self.version
-
-end Dependency
 
 namespace DSL
 
@@ -417,6 +715,21 @@ scoped syntax (name := externLibCommand)
 : command
 
 /--
+为包定义新的自定义目标。只有一种形式：
+
+```lean
+target «target-name» (pkg : NPackage _package.name) : α :=
+  /- build term of type `FetchM (Job α)` -/
+```
+
+`pkg` 参数（及其类型说明符）可省略。
+其类型为 `NPackage _package.name`，以可证明地表明所提供的包就是定义该目标的包。
+-/
+scoped syntax (name := targetCommand)
+  (docComment)? (Term.attributes)? "target " buildDeclSig
+: command
+
+/--
 定义新的包分面。只有一种形式：
 
 ```lean
@@ -464,7 +777,7 @@ scoped syntax (name := moduleFacetDecl)
 **示例**
 
 ```
-/-- Display a greeting -/
+/-- 显示问候语 -/
 script «script-name» (args) do
   if h : 0 < args.length then
     IO.println s!"Hello, {args[0]'h}!"

--- a/Manual/ZhDocString/BuildTools/Lake.lean
+++ b/Manual/ZhDocString/BuildTools/Lake.lean
@@ -1,0 +1,162 @@
+/-
+Copyright (c) 2026 Lean 中文社区. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Lean 中文社区
+-/
+import Lake
+import Manual.ZhDocString.ZhDocString
+
+namespace ZhDoc.BuildTools.Lake
+
+/--
+`Script` 所用的单子类型。
+
+它是一个 `IO` 单子，并配备了有关 Lake 配置的信息。
+-/
+abbrev ScriptM := _root_.Lake.ScriptM
+
+/-- 配备了（只读的）已探测 Lake 环境的单子。 -/
+abbrev MonadLakeEnv (m : Type → Type u) := _root_.Lake.MonadLakeEnv m
+
+/--
+获取当前 Lake 环境。
+-/
+def getLakeEnv := @_root_.Lake.getLakeEnv
+
+/-- 返回 Lake 配置中的 `LAKE_NO_CACHE`/`--no-cache`。 -/
+def getNoCache := @_root_.Lake.getNoCache
+
+/-- 返回 Lake 配置中的 `LAKE_NO_CACHE`/`--no-cache` 是否**未**设置。 -/
+def getTryCache := @_root_.Lake.getTryCache
+
+/-- 返回 Lake 环境的 `LAKE_PACKAGE_URL_MAP`。若不存在则为空。 -/
+def getPkgUrlMap := @_root_.Lake.getPkgUrlMap
+
+/-- 返回 Lake 环境的 Elan 工具链名称。若不存在则为空。 -/
+def getElanToolchain := @_root_.Lake.getElanToolchain
+
+/-- 返回 Lake 环境中探测到的 `LEAN_PATH` 值。 -/
+def getEnvLeanPath := @_root_.Lake.getEnvLeanPath
+
+/-- 返回 Lake 环境中探测到的 `LEAN_SRC_PATH` 值。 -/
+def getEnvLeanSrcPath := @_root_.Lake.getEnvLeanSrcPath
+
+/-- 返回 Lake 环境中探测到的 `sharedLibPathEnvVar` 值。 -/
+def getEnvSharedLibPath := @_root_.Lake.getEnvSharedLibPath
+
+/-- 返回探测到的 Elan 安装（若存在）。 -/
+def getElanInstall? := @_root_.Lake.getElanInstall?
+
+/-- 返回探测到的 Elan 安装的根目录（即 `ELAN_HOME`）。 -/
+def getElanHome? := @_root_.Lake.getElanHome?
+
+/-- 返回探测到的 Elan 安装中 `elan` 二进制文件的路径。 -/
+def getElan? := @_root_.Lake.getElan?
+
+/-- 返回探测到的 Lean 安装。 -/
+def getLeanInstall := @_root_.Lake.getLeanInstall
+
+/-- 返回探测到的 Lean 安装的根目录。 -/
+def getLeanSysroot := @_root_.Lake.getLeanSysroot
+
+/-- 返回探测到的 Lean 安装的 Lean 源码目录。 -/
+def getLeanSrcDir := @_root_.Lake.getLeanSrcDir
+
+/-- 返回探测到的 Lean 安装的 Lean 库目录。 -/
+def getLeanLibDir := @_root_.Lake.getLeanLibDir
+
+/-- 返回探测到的 Lean 安装的 C 头文件目录。 -/
+def getLeanIncludeDir := @_root_.Lake.getLeanIncludeDir
+
+/-- 返回探测到的 Lean 安装的系统库目录。 -/
+def getLeanSystemLibDir := @_root_.Lake.getLeanSystemLibDir
+
+/-- 返回探测到的 Lean 安装中 `lean` 二进制文件的路径。 -/
+def getLean := @_root_.Lake.getLean
+
+/-- 返回探测到的 Lean 安装中 `leanc` 二进制文件的路径。 -/
+def getLeanc := @_root_.Lake.getLeanc
+
+/--
+返回探测到的 Lean 安装中主核心共享库
+（即 `libleanshared`）的路径。
+-/
+def getLeanSharedLib := @_root_.Lake.getLeanSharedLib
+
+/-- 返回探测到的 Lean 安装中 `ar` 二进制文件的路径。 -/
+def getLeanAr := @_root_.Lake.getLeanAr
+
+/-- 返回探测到的 Lean 安装中 C 编译器的路径。 -/
+def getLeanCc := @_root_.Lake.getLeanCc
+
+/-- 返回探测到的 Lean 安装中可选的 `LEAN_CC` 编译器覆盖值。 -/
+def getLeanCc? := @_root_.Lake.getLeanCc?
+
+/-- 返回探测到的 Lake 安装。 -/
+def getLakeInstall := @_root_.Lake.getLakeInstall
+
+/-- 返回探测到的 Lake 安装的根目录（例如 `LAKE_HOME`）。 -/
+def getLakeHome := @_root_.Lake.getLakeHome
+
+/-- 返回探测到的 Lake 安装的源码目录。 -/
+def getLakeSrcDir := @_root_.Lake.getLakeSrcDir
+
+/-- 返回探测到的 Lake 安装的 Lean 库目录。 -/
+def getLakeLibDir := @_root_.Lake.getLakeLibDir
+
+/-- 返回探测到的 Lake 安装中 `lake` 二进制文件的路径。 -/
+def getLake := @_root_.Lake.getLake
+
+/-- 配备了（只读的）Lake `Workspace` 的单子。 -/
+class MonadWorkspace (m : Type → Type u) where
+  /-- 获取当前 Lake 工作区。 -/
+  getWorkspace : m _root_.Lake.Workspace
+
+/-- 返回上下文工作区的根包。 -/
+def getRootPackage := @_root_.Lake.getRootPackage
+
+/--
+返回工作区中首个（若存在）被赋予 `name` 的包。
+
+这可用于查找与用户提供的名称对应的包。如果已经有该包的唯一标识符，请改用
+`findPackageByKey?`。
+-/
+def findPackageByName? := @_root_.Lake.findPackageByName?
+
+/-- 返回工作区中由 `keyName` 标识的唯一包（若存在）。 -/
+def findPackageByKey? := @_root_.Lake.findPackageByKey?
+
+/-- 在工作区中定位具有给定名称、可构建、可导入且位于本地的模块。 -/
+def findModule? := @_root_.Lake.findModule?
+
+/-- 尝试在工作区中查找具有给定名称的 Lean 可执行文件。 -/
+def findLeanExe? := @_root_.Lake.findLeanExe?
+
+/-- 尝试在工作区中查找具有给定名称的 Lean 库。 -/
+def findLeanLib? := @_root_.Lake.findLeanLib?
+
+/-- 尝试在工作区中查找具有给定名称的外部库。 -/
+def findExternLib? := @_root_.Lake.findExternLib?
+
+/-- 返回上下文工作区添加到 `LEAN_PATH` 的路径。 -/
+def getLeanPath := @_root_.Lake.getLeanPath
+
+/-- 返回上下文工作区添加到 `LEAN_SRC_PATH` 的路径。 -/
+def getLeanSrcPath := @_root_.Lake.getLeanSrcPath
+
+/-- 返回上下文工作区添加到共享库路径的路径。 -/
+def getSharedLibPath := @_root_.Lake.getSharedLibPath
+
+/-- 返回上下文工作区设置的扩充后 `LEAN_PATH`。 -/
+def getAugmentedLeanPath := @_root_.Lake.getAugmentedLeanPath
+
+/-- 返回上下文工作区设置的扩充后 `LEAN_SRC_PATH`。 -/
+def getAugmentedLeanSrcPath := @_root_.Lake.getAugmentedLeanSrcPath
+
+/-- 返回上下文工作区设置的扩充后共享库路径。 -/
+def getAugmentedSharedLibPath := @_root_.Lake.getAugmentedSharedLibPath
+
+/-- 返回上下文工作区设置的扩充后环境变量。 -/
+def getAugmentedEnv := @_root_.Lake.getAugmentedEnv
+
+end ZhDoc.BuildTools.Lake

--- a/Manual/ZhDocString/BuildTools/Smoke.lean
+++ b/Manual/ZhDocString/BuildTools/Smoke.lean
@@ -114,7 +114,7 @@ tag := "chapter-24-zhdocstring-smoke"
 
 {zhincludeDocstring Lake.DSL.externLibCommand ZhDoc.BuildTools.Config.DSL.externLibCommand}
 
-{zhincludeDocstring Lake.DSL.externLibCommand ZhDoc.BuildTools.Config.DSL.externLibCommand}
+{zhincludeDocstring Lake.DSL.targetCommand ZhDoc.BuildTools.Config.DSL.targetCommand}
 
 {zhincludeDocstring Lake.DSL.packageFacetDecl ZhDoc.BuildTools.Config.DSL.packageFacetDecl}
 
@@ -132,7 +132,7 @@ tag := "chapter-24-zhdocstring-smoke"
 
 {zhincludeDocstring Lake.DSL.scriptDecl ZhDoc.BuildTools.Config.DSL.scriptDecl}
 
-{zhdocstring Lake.ScriptM ZhDoc.BuildTools.Config.ScriptM}
+{zhdocstring Lake.ScriptM ZhDoc.BuildTools.Lake.ScriptM}
 
 {zhincludeDocstring Lake.DSL.dirConst ZhDoc.BuildTools.Config.DSL.dirConst}
 

--- a/Manual/ZhDocString/BuildTools/Smoke.lean
+++ b/Manual/ZhDocString/BuildTools/Smoke.lean
@@ -1,0 +1,145 @@
+import Manual.BuildTools
+
+open Verso.Genre Manual
+
+#doc (Manual) "第 24 章中文动态文档冒烟测试" =>
+%%%
+file := "Chapter 24 ZhDocString Smoke Test"
+tag := "chapter-24-zhdocstring-smoke"
+%%%
+
+{zhdocstring Lake.ScriptM ZhDoc.BuildTools.Lake.ScriptM}
+
+{zhdocstring Lake.MonadLakeEnv ZhDoc.BuildTools.Lake.MonadLakeEnv}
+
+{zhdocstring Lake.getLakeEnv ZhDoc.BuildTools.Lake.getLakeEnv}
+
+{zhdocstring Lake.getNoCache ZhDoc.BuildTools.Lake.getNoCache}
+
+{zhdocstring Lake.getTryCache ZhDoc.BuildTools.Lake.getTryCache}
+
+{zhdocstring Lake.getPkgUrlMap ZhDoc.BuildTools.Lake.getPkgUrlMap}
+
+{zhdocstring Lake.getElanToolchain ZhDoc.BuildTools.Lake.getElanToolchain}
+
+{zhdocstring Lake.getEnvLeanPath ZhDoc.BuildTools.Lake.getEnvLeanPath}
+
+{zhdocstring Lake.getEnvLeanSrcPath ZhDoc.BuildTools.Lake.getEnvLeanSrcPath}
+
+{zhdocstring Lake.getEnvSharedLibPath ZhDoc.BuildTools.Lake.getEnvSharedLibPath}
+
+{zhdocstring Lake.getElanInstall? ZhDoc.BuildTools.Lake.getElanInstall?}
+
+{zhdocstring Lake.getElanHome? ZhDoc.BuildTools.Lake.getElanHome?}
+
+{zhdocstring Lake.getElan? ZhDoc.BuildTools.Lake.getElan?}
+
+{zhdocstring Lake.getLeanInstall ZhDoc.BuildTools.Lake.getLeanInstall}
+
+{zhdocstring Lake.getLeanSysroot ZhDoc.BuildTools.Lake.getLeanSysroot}
+
+{zhdocstring Lake.getLeanSrcDir ZhDoc.BuildTools.Lake.getLeanSrcDir}
+
+{zhdocstring Lake.getLeanLibDir ZhDoc.BuildTools.Lake.getLeanLibDir}
+
+{zhdocstring Lake.getLeanIncludeDir ZhDoc.BuildTools.Lake.getLeanIncludeDir}
+
+{zhdocstring Lake.getLeanSystemLibDir ZhDoc.BuildTools.Lake.getLeanSystemLibDir}
+
+{zhdocstring Lake.getLean ZhDoc.BuildTools.Lake.getLean}
+
+{zhdocstring Lake.getLeanc ZhDoc.BuildTools.Lake.getLeanc}
+
+{zhdocstring Lake.getLeanSharedLib ZhDoc.BuildTools.Lake.getLeanSharedLib}
+
+{zhdocstring Lake.getLeanAr ZhDoc.BuildTools.Lake.getLeanAr}
+
+{zhdocstring Lake.getLeanCc ZhDoc.BuildTools.Lake.getLeanCc}
+
+{zhdocstring Lake.getLeanCc? ZhDoc.BuildTools.Lake.getLeanCc?}
+
+{zhdocstring Lake.getLakeInstall ZhDoc.BuildTools.Lake.getLakeInstall}
+
+{zhdocstring Lake.getLakeHome ZhDoc.BuildTools.Lake.getLakeHome}
+
+{zhdocstring Lake.getLakeSrcDir ZhDoc.BuildTools.Lake.getLakeSrcDir}
+
+{zhdocstring Lake.getLakeLibDir ZhDoc.BuildTools.Lake.getLakeLibDir}
+
+{zhdocstring Lake.getLake ZhDoc.BuildTools.Lake.getLake}
+
+{zhdocstring Lake.MonadWorkspace ZhDoc.BuildTools.Lake.MonadWorkspace}
+
+{zhdocstring Lake.getRootPackage ZhDoc.BuildTools.Lake.getRootPackage}
+
+{zhdocstring Lake.findPackageByName? ZhDoc.BuildTools.Lake.findPackageByName?}
+
+{zhdocstring Lake.findPackageByKey? ZhDoc.BuildTools.Lake.findPackageByKey?}
+
+{zhdocstring Lake.findModule? ZhDoc.BuildTools.Lake.findModule?}
+
+{zhdocstring Lake.findLeanExe? ZhDoc.BuildTools.Lake.findLeanExe?}
+
+{zhdocstring Lake.findLeanLib? ZhDoc.BuildTools.Lake.findLeanLib?}
+
+{zhdocstring Lake.findExternLib? ZhDoc.BuildTools.Lake.findExternLib?}
+
+{zhdocstring Lake.getLeanPath ZhDoc.BuildTools.Lake.getLeanPath}
+
+{zhdocstring Lake.getLeanSrcPath ZhDoc.BuildTools.Lake.getLeanSrcPath}
+
+{zhdocstring Lake.getSharedLibPath ZhDoc.BuildTools.Lake.getSharedLibPath}
+
+{zhdocstring Lake.getAugmentedLeanPath ZhDoc.BuildTools.Lake.getAugmentedLeanPath}
+
+{zhdocstring Lake.getAugmentedLeanSrcPath ZhDoc.BuildTools.Lake.getAugmentedLeanSrcPath}
+
+{zhdocstring Lake.getAugmentedSharedLibPath ZhDoc.BuildTools.Lake.getAugmentedSharedLibPath}
+
+{zhdocstring Lake.getAugmentedEnv ZhDoc.BuildTools.Lake.getAugmentedEnv}
+
+{zhincludeDocstring Lake.Package.defaultTargets ZhDoc.BuildTools.Config.Package.defaultTargets}
+
+{zhincludeDocstring Lake.Dependency.version ZhDoc.BuildTools.Config.Dependency.version}
+
+{zhincludeDocstring Lake.DSL.declField ZhDoc.BuildTools.Config.DSL.declField}
+
+{zhincludeDocstring Lake.DSL.postUpdateDecl ZhDoc.BuildTools.Config.DSL.postUpdateDecl}
+
+{zhincludeDocstring Lake.DSL.fromClause ZhDoc.BuildTools.Config.DSL.fromClause}
+
+{zhdocstring Lake.LeanLibConfig ZhDoc.BuildTools.Config.LeanLibConfig}
+
+{zhdocstring Lake.LeanExeConfig ZhDoc.BuildTools.Config.LeanExeConfig}
+
+{zhincludeDocstring Lake.DSL.externLibCommand ZhDoc.BuildTools.Config.DSL.externLibCommand}
+
+{zhincludeDocstring Lake.DSL.externLibCommand ZhDoc.BuildTools.Config.DSL.externLibCommand}
+
+{zhincludeDocstring Lake.DSL.packageFacetDecl ZhDoc.BuildTools.Config.DSL.packageFacetDecl}
+
+{zhincludeDocstring Lake.DSL.libraryFacetDecl ZhDoc.BuildTools.Config.DSL.libraryFacetDecl}
+
+{zhincludeDocstring Lake.DSL.moduleFacetDecl ZhDoc.BuildTools.Config.DSL.moduleFacetDecl}
+
+{zhdocstring Lake.BuildType ZhDoc.BuildTools.Config.BuildType}
+
+{zhdocstring Lake.Glob ZhDoc.BuildTools.Config.Glob}
+
+{zhdocstring Lake.LeanOption ZhDoc.BuildTools.Config.LeanOption}
+
+{zhdocstring Lake.Backend ZhDoc.BuildTools.Config.Backend}
+
+{zhincludeDocstring Lake.DSL.scriptDecl ZhDoc.BuildTools.Config.DSL.scriptDecl}
+
+{zhdocstring Lake.ScriptM ZhDoc.BuildTools.Config.ScriptM}
+
+{zhincludeDocstring Lake.DSL.dirConst ZhDoc.BuildTools.Config.DSL.dirConst}
+
+{zhincludeDocstring Lake.DSL.getConfig ZhDoc.BuildTools.Config.DSL.getConfig}
+
+{zhincludeDocstring Lake.DSL.metaIf ZhDoc.BuildTools.Config.DSL.metaIf}
+
+{zhincludeDocstring Lake.DSL.cmdDo ZhDoc.BuildTools.Config.DSL.cmdDo}
+
+{zhincludeDocstring Lake.DSL.runIO ZhDoc.BuildTools.Config.DSL.runIO}

--- a/scripts/localize-generated-html.py
+++ b/scripts/localize-generated-html.py
@@ -74,6 +74,9 @@ TARGET_PAGES = (
     "Notations-and-Macros/Elaborators/index.html",
     "Notations-and-Macros/Extending--do--Notation/index.html",
     "Notations-and-Macros/Extending-Lean___s-Output/index.html",
+    "Build-Tools-and-Distribution/index.html",
+    "Build-Tools-and-Distribution/Lake/index.html",
+    "Build-Tools-and-Distribution/Managing-Toolchains-with-Elan/index.html",
 )
 
 HOVER_ATTR_RE = re.compile(r'data-verso-hover="([^"]+)"')

--- a/scripts/localize-generated-html.py
+++ b/scripts/localize-generated-html.py
@@ -234,6 +234,17 @@ def strip_english_inline_docstrings(text: str) -> str:
     return DOCSTRING_RE.sub(replace, text)
 
 
+def add_stable_alias_anchor(text: str, stable_id: str, generated_id: str) -> str:
+    """Preserve an upstream fragment when duplicate definitions receive a `-next` ID."""
+    if f'id="{stable_id}"' in text or f'id="{generated_id}"' not in text:
+        return text
+    marker = f'<code class="env-var" id="{generated_id}">'
+    if marker not in text:
+        raise SystemExit(f"cannot place stable alias for generated anchor {generated_id!r}")
+    replacement = f'<span id="{stable_id}"></span>' + marker
+    return text.replace(marker, replacement, 1)
+
+
 def localize_generated_html(root: Path) -> tuple[int, int, int, int]:
     docs_path = root / "-verso-docs.json"
     if not docs_path.is_file():
@@ -252,6 +263,7 @@ def localize_generated_html(root: Path) -> tuple[int, int, int, int]:
         text = path.read_text(encoding="utf-8")
         text = text.replace(">Table of Contents<", ">目录<")
         text = localize_link_metadata(text)
+        text = add_stable_alias_anchor(text, "ELAN_HOME", "ELAN_HOME-next")
         if rel.startswith(("Tactic-Proofs/", "Notations-and-Macros/")):
             text = localize_tactic_namedocs(text, namedocs_translations)
         parser = NamedDocsParser()


### PR DESCRIPTION
## 概要

完成参考手册第 24 章 **Build Tools and Distribution** 中文化：

- 翻译 Build Tools、Elan、Lake、Lake CLI 与配置文件章节的全部静态正文；
- 保留官方路由、70 个嵌套标题锚点、19 个稳定示例提取路径及术语键；
- 为 68 个动态 API 调用建立真实声明形状的中文 carrier，并加入完整 renderer Smoke；
- 从源头扩展 `tomlTableDocs (docs := …)`，以真实 Lake 结构生成字段类型、ID 与 xref，同时从 shape-faithful carrier 获取中文顶层/字段文档；
- 中文化 TOML 表生成 UI、搜索元数据、hover 与页面 chrome；
- 修复上游文档中的 `targetCommand`、`check-test`、依赖方向、`testDriver` 示例及默认目录等技术错误；
- 保留重复环境变量定义的上游稳定 fragment。

## 验证

- `lake -Kjobs=4 build`：1082 jobs 成功；
- `lake -Kjobs=2 build Manual.ZhDocString.Smoke Manual.ZhDocString.BuildTools.Smoke`：293 jobs 成功；
- `scripts/check-examples-isolated.sh`：356/356 成功；
- 5/5 源文件结构守恒：74 headings、306 directives、135 fences、655 roles、729 inline atoms、197 effective terminology keys；
- 动态文档：68/68 调用，70 对根文档与 71 对字段文档 Markdown 结构守恒；
- Preview/Production 三页及 `-verso-docs.json` 字节一致；
- 生成物：0 缺失路由、0 缺失 fragment、0 重复 ID、0 英文 hover、0 可见英文候选；
- 后处理二次运行字节幂等；
- carrier 中无 `axiom`、`sorry`、`admit`、`opaque`，无项目自定义公理。
